### PR TITLE
1.15.0 Adição de cartão animado no checkout do editor por blocos

### DIFF
--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -87,7 +87,7 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
         }
 
         $post = get_post();
-        if ($post && has_shortcode($post->post_content, 'woocommerce_checkout')) {
+        if ($post && has_shortcode($post->post_content, 'woocommerce_checkout') && $gateway_enabled['enabled'] === 'yes') {
             wp_enqueue_script('lkn-fix-script', plugin_dir_url(__FILE__) . '../resources/js/frontend/lkn-dc-script-fix.js', array('wp-i18n', 'jquery'), $this->version, false);
             wp_localize_script('lkn-fix-script', 'lknWcCieloPaymentGatewayToken', $this->accessToken['access_token']);
         }


### PR DESCRIPTION
* Adição de função para renovar token;
> Uma função de renovação automática do token da Cielo foi implementado para situações em que o token expira durante o processo de checkout. Essa funcionalidade garante que o pagamento continue sem interrupções.

* Adição de configuração para exibir logs de transação no pedido;
> Uma configuração foi adicionada para permitir a exibição dos logs das transações diretamente na página de edição de pedidos no WooCommerce. Essa funcionalidade facilita o acompanhamento e a análise das transações associadas a cada pedido.
![image](https://github.com/user-attachments/assets/287662c1-ca98-4639-adbe-6cbab37d42cc)
![image](https://github.com/user-attachments/assets/d49e49a7-a275-413f-9337-22c0f56144ea)

* Adição de configuração para exibir e ocultar cartão animado;
> Uma nova configuração foi adicionada para permitir a exibição de um cartão animado durante o processo de checkout.
![image](https://github.com/user-attachments/assets/aa7cecd2-0586-41d7-82f4-adecbc0246bd)
![image](https://github.com/user-attachments/assets/8eb1a80e-ede9-4eb3-b8df-22f646c760da)

* Adição de seleção automática das abas quando a página configurações é recarregada.
> Uma funcionalidade foi adicionada para manter automaticamente a aba selecionada ao recarregar a página de configurações.
![image](https://github.com/user-attachments/assets/373d187e-9efe-4dfe-9b41-81a77145020b)

* Alteração de label do método de pagamento de crédito;
> O label do método de pagamento de crédito foi alterado de "Cielo - Cartão de Crédito" para "Cielo - Cartão de Crédito Legado"
![image](https://github.com/user-attachments/assets/2770a09d-32ae-47db-9b59-880237f4fb5c)

* Alteração em urls de endpoints.
> As URLs dos endpoints foram ajustadas para serem geradas dinamicamente, garantindo compatibilidade com as configurações de URL definidas no WordPress.

* Correção em chamada da função para gerar token 3DS
> A função para gerar o token 3DS era chamada mesmo quando o método de pagamento estava desabilitado. Esse comportamento foi corrigido, e agora a função só é executada quando o método está habilitado.



