### PR TITLE
1.17.2 - wc_cielo_payment_gateway (Validação da opção de cartão online no momento do pagamento)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: "1.17.1"
+        custom_tag: "1.17.2"
 
     # Generate new release
     - name: Generate new Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.17.2 - 24/02/2025
+* Validação da opção de cartão online no momento do pagamento.
+
 # 1.17.1 - 17/02/2025
 * Correção de referência de valor mínimo das parcelas;
 * Atualização de referência de hooks para evitar colisões;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.17.2 - 24/02/2025
-* Validação da opção de cartão online no momento do pagamento.
+* Validação da opção de cartão online no momento do pagamento;
+* Correção de exibição de moeda nas parcelas.
 
 # 1.17.1 - 17/02/2025
 * Correção de referência de valor mínimo das parcelas;

--- a/README.txt
+++ b/README.txt
@@ -100,7 +100,8 @@ This plugin uses the [React Credit Cards](https://github.com/amaroteam/react-cre
 == Changelog ==
 = 1.17.2 =
 **24/02/2025**
-* Validation of the online card option at the time of payment.
+* Validation of the online card option at the time of payment;
+* Fix currency display in installments.
 
 = 1.17.1 =
 **17/02/2025**

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
 Tags: woocommerce, payment, paymethod, card, credit
 Requires at least: 5.7
 Tested up to: 6.7
-Stable tag: 1.17.1
+Stable tag: 1.17.2
 Requires PHP: 7.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -98,6 +98,10 @@ This plugin uses the [React Credit Cards](https://github.com/amaroteam/react-cre
 7. Debit card front page with payment fields.
 
 == Changelog ==
+= 1.17.2 =
+**24/02/2025**
+* Validation of the online card option at the time of payment.
+
 = 1.17.1 =
 **17/02/2025**
 * Correction of reference for minimum value of installments;

--- a/includes/LknWCGatewayCieloCredit.php
+++ b/includes/LknWCGatewayCieloCredit.php
@@ -19,7 +19,7 @@ use WC_Subscription;
  */
 
 // Exit if accessed directly.
-if ( ! defined('ABSPATH')) {
+if (! defined('ABSPATH')) {
     exit;
 }
 
@@ -30,7 +30,8 @@ if ( ! defined('ABSPATH')) {
  *
  * @version  1.0.0
  */
-final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
+final class LknWCGatewayCieloCredit extends WC_Payment_Gateway
+{
     /**
      * Define instructions to configure and use this plugin.
      *
@@ -61,7 +62,8 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
     /**
      * Constructor for the gateway.
      */
-    public function __construct() {
+    public function __construct()
+    {
         $this->id = 'lkn_cielo_credit';
         $this->icon = apply_filters('lkn_wc_cielo_gateway_icon', '');
         $this->has_fields = true;
@@ -106,14 +108,16 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
      * @param  WC_Order  $order
      * @return void
      */
-    public function process_subscription_payment($amount, $order, $isRetry = false): void {
+    public function process_subscription_payment($amount, $order, $isRetry = false): void
+    {
         do_action('lkn_wc_cielo_scheduled_subscription_payment', $amount, $order, $isRetry);
     }
 
     /**
      * Load admin JavaScript for the admin page.
      */
-    public function admin_load_script(): void {
+    public function admin_load_script(): void
+    {
         wp_enqueue_script('lkn-wc-gateway-admin', plugin_dir_url(__FILE__) . '../resources/js/admin/lkn-wc-gateway-admin.js', array('wp-i18n'), $this->version, 'all');
 
         $page = isset($_GET['page']) ? sanitize_text_field(wp_unslash($_GET['page'])) : '';
@@ -148,7 +152,8 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
     /**
      * Load gateway scripts/styles.
      */
-    public function payment_gateway_scripts(): void {
+    public function payment_gateway_scripts(): void
+    {
         // Don't load scripts outside payment page
         if (
             ! is_checkout()
@@ -182,7 +187,8 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
     /**
      * Initialise Gateway Settings Form Fields.
      */
-    public function init_form_fields(): void {
+    public function init_form_fields(): void
+    {
         $this->form_fields = array(
             'general' => array(
                 'title' => esc_attr__('General', 'lkn-wc-gateway-cielo'),
@@ -317,7 +323,7 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
 
         $customConfigs = apply_filters('lkn_wc_cielo_get_custom_configs', array(), $this->id);
 
-        if ( ! empty($customConfigs)) {
+        if (! empty($customConfigs)) {
             $this->form_fields = array_merge($this->form_fields, $customConfigs);
         }
     }
@@ -325,7 +331,8 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
     /**
      * Render the payment fields.
      */
-    public function payment_fields(): void {
+    public function payment_fields(): void
+    {
         $activeInstallment = $this->get_option('installment_payment');
         $total_cart = number_format($this->get_order_total(), 2, '.', '');
         $noLoginCheckout = isset($_GET['pay_for_order']) ? sanitize_text_field(wp_unslash($_GET['pay_for_order'])) : 'false';
@@ -498,11 +505,12 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
      *
      * @return bool
      */
-    public function validate_fields() {
+    public function validate_fields()
+    {
         $validateCompatMode = $this->get_option('input_validation_compatibility', 'no');
         $nonce = isset($_POST['nonce_lkn_cielo_credit']) ? sanitize_text_field(wp_unslash($_POST['nonce_lkn_cielo_credit'])) : '';
 
-        if ( ! wp_verify_nonce($nonce, 'nonce_lkn_cielo_credit') && 'no' === $validateCompatMode) {
+        if (! wp_verify_nonce($nonce, 'nonce_lkn_cielo_credit') && 'no' === $validateCompatMode) {
             $this->log->log('error', 'Nonce verification failed. Nonce: ' . var_export($nonce, true), array('source' => 'woocommerce-cielo-credit'));
             $this->add_notice_once(__('Nonce verification failed, try reloading the page', 'lkn-wc-gateway-cielo'), 'error');
             return false;
@@ -533,14 +541,15 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
      *
      * @return array
      */
-    public function process_payment($order_id) {
+    public function process_payment($order_id)
+    {
         $nonceInactive = $this->get_option('nonce_compatibility', 'no');
         $nonce = isset($_POST['nonce_lkn_cielo_credit']) ? sanitize_text_field(wp_unslash($_POST['nonce_lkn_cielo_credit'])) : '';
 
-        if ( ! wp_verify_nonce($nonce, 'nonce_lkn_cielo_credit') && 'no' === $nonceInactive) {
+        if (! wp_verify_nonce($nonce, 'nonce_lkn_cielo_credit') && 'no' === $nonceInactive) {
             $this->log->log('error', 'Nonce verification failed. Nonce: ' . var_export($nonce, true), array('source' => 'woocommerce-cielo-credit'));
             $this->add_notice_once(__('Nonce verification failed, try reloading the page', 'lkn-wc-gateway-cielo'), 'error');
-            throw new Exception(esc_attr(__('Nonce verification failed, try reloading the page2', 'lkn-wc-gateway-cielo')));
+            throw new Exception(esc_attr(__('Nonce verification failed, try reloading the page', 'lkn-wc-gateway-cielo')));
         }
 
         $order = wc_get_order($order_id);
@@ -721,7 +730,7 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
                 // Salvar o token e a bandeira do cartão no meta do pedido
                 $user_id = $order->get_user_id();
 
-                if ( ! isset($responseDecoded->Payment->CreditCard->CardToken)) {
+                if (! isset($responseDecoded->Payment->CreditCard->CardToken)) {
                     $order->add_order_note('O token para cobranças automáticas não foi gerado, então as cobranças automáticas não poderão ser efetuadas.');
                 }
 
@@ -736,7 +745,7 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
                     $cardsArray = is_array($cardsArray) ? $cardsArray : array();
                     $lastFourDigits = $responseDecoded->Payment->CreditCard->CardNumber;
                     $expirationDate = $responseDecoded->Payment->CreditCard->ExpirationDate;
-    
+
                     // Adiciona o novo cartão à lista
                     $cardsArray[] = array(
                         'cardToken' => $cardPayment['cardToken'],
@@ -744,7 +753,7 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
                         'cardDigits' => $lastFourDigits,
                         'expirationDate' => $expirationDate,
                     );
-    
+
                     // Atualiza os metadados do usuário
                     update_user_meta($user_id, 'card_array', $cardsArray);
                     update_user_meta($user_id, 'default_card', array_key_last($cardsArray));
@@ -814,7 +823,8 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
     /**
      * Calculate the total value of items in the WooCommerce cart.
      */
-    public static function lknGetCartTotal() {
+    public static function lknGetCartTotal()
+    {
         $cart = WC()->cart;
 
         if (empty($cart)) {
@@ -841,7 +851,8 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
      *
      * @return bool
      */
-    public function process_refund($order_id, $amount = null, $reason = '') {
+    public function process_refund($order_id, $amount = null, $reason = '')
+    {
         // Do your refund here. Refund $amount for the order with ID $order_id
         $url = ($this->get_option('env') == 'production') ? 'https://api.cieloecommerce.cielo.com.br/' : 'https://apisandbox.cieloecommerce.cielo.com.br/';
         $merchantId = sanitize_text_field($this->get_option('merchant_id'));
@@ -885,7 +896,8 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
      *
      * @return bool
      */
-    private function validate_card_number($ccnum, $renderNotice) {
+    private function validate_card_number($ccnum, $renderNotice)
+    {
         if (empty($ccnum)) {
             if ($renderNotice) {
                 $this->add_notice_once(__('Credit Card number is required!', 'lkn-wc-gateway-cielo'), 'error');
@@ -906,7 +918,8 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
         return true;
     }
 
-    private function validate_card_holder_name($cardName, $renderNotice) {
+    private function validate_card_holder_name($cardName, $renderNotice)
+    {
         if (empty($cardName) || strlen($cardName) < 3) {
             if ($renderNotice) {
                 $this->add_notice_once(__('Card Holder Name is required!', 'lkn-wc-gateway-cielo'), 'error');
@@ -926,7 +939,8 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
      *
      * @return bool
      */
-    private function validate_exp_date($expDate, $renderNotice) {
+    private function validate_exp_date($expDate, $renderNotice)
+    {
         if (empty($expDate)) {
             if ($renderNotice) {
                 $this->add_notice_once(__('Expiration date is required!', 'lkn-wc-gateway-cielo'), 'error');
@@ -966,7 +980,8 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
      *
      * @return bool
      */
-    private function validate_cvv($cvv, $renderNotice) {
+    private function validate_cvv($cvv, $renderNotice)
+    {
         if (empty($cvv)) {
             if ($renderNotice) {
                 $this->add_notice_once(__('CVV is required!', 'lkn-wc-gateway-cielo'), 'error');
@@ -993,8 +1008,9 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
      * @param string $message
      * @param string $type
      */
-    private function add_notice_once($message, $type): void {
-        if ( ! wc_has_notice($message, $type)) {
+    private function add_notice_once($message, $type): void
+    {
+        if (! wc_has_notice($message, $type)) {
             wc_add_notice($message, $type);
         }
     }
@@ -1006,7 +1022,8 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway {
      *
      * @return string|bool
      */
-    private function get_card_provider($cardNumber) {
+    private function get_card_provider($cardNumber)
+    {
         $brand = '';
         $brand = apply_filters('lkn_wc_cielo_get_card_brand', $brand, $cardNumber, $this->id);
 

--- a/includes/LknWCGatewayCieloCredit.php
+++ b/includes/LknWCGatewayCieloCredit.php
@@ -172,6 +172,16 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway
 
         $installmentArgs = array();
         $installmentArgs = apply_filters('lkn_wc_cielo_js_credit_args', array('installment_min' => '5'));
+        $order_id = absint(get_query_var('order-pay'));
+        $order = wc_get_order($order_id);
+
+        if ($order) {
+            $currency = $order->get_currency();
+        } else {
+            $currency = get_woocommerce_currency();
+        }
+
+        $installmentArgs['currency'] = $currency;
 
         wp_enqueue_script('lkn-mask-script', plugin_dir_url(__FILE__) . '../resources/js/frontend/formatter.js', array('jquery'), $this->version, false);
         wp_enqueue_script('lkn-mask-script-load', plugin_dir_url(__FILE__) . '../resources/js/frontend/define-mask.js', array('lkn-mask-script', 'jquery'), $this->version, false);

--- a/includes/LknWCGatewayCieloCredit.php
+++ b/includes/LknWCGatewayCieloCredit.php
@@ -73,7 +73,7 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway
 
         $this->supports = apply_filters('lkn_wc_cielo_credit_add_support', $this->supports);
 
-        $this->method_title = __('Cielo - Credit Card Legacy', 'lkn-wc-gateway-cielo');
+        $this->method_title = __('Cielo - Credit Card', 'lkn-wc-gateway-cielo');
         $this->method_description = __('Allows credit card payment with Cielo API 3.0.', 'lkn-wc-gateway-cielo');
 
         // Load the settings.

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -1077,6 +1077,17 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
         $debug = $this->get_option('debug');
         $currency = $order->get_currency();
         $activeInstallment = $this->get_option('installment_payment');
+
+        if (empty($provider)) {
+            $message = __("Bin query is not enabled for this merchant.", 'lkn-wc-gateway-cielo');
+
+            if ('yes' === $debug) {
+                $this->log->log('error', var_export($message, true), array('source' => 'woocommerce-cielo-debit'));
+            }
+
+            throw new Exception(esc_attr($message));
+        }
+
         if ($this->validate_card_holder_name($cardName, false) === false) {
             $message = __('Card Holder Name is required!', 'lkn-wc-gateway-cielo');
 
@@ -1275,17 +1286,6 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
         }
 
         $response = wp_remote_post($url . '1/sales', $args);
-
-        $jsonResponse = json_decode($response['body']);
-
-        if (is_array($jsonResponse) && isset($jsonResponse[0]) && isset($jsonResponse[0]->Code) && $jsonResponse[0]->Code === 323) {
-            if ('yes' === $debug) {
-                $this->log->log('error', var_export($jsonResponse[0]->Message, true), array('source' => 'woocommerce-cielo-debit'));
-            }
-            $message = __("Bin query is not enabled for this merchant.", 'lkn-wc-gateway-cielo');
-
-            throw new Exception(esc_attr($message));
-        }
 
         /*  throw new Exception(json_encode($args)); */
         if (is_wp_error($response)) {

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -1278,7 +1278,7 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
 
         $jsonResponse = json_decode($response['body']);
 
-        if (isset($jsonResponse[0]->Code) && $jsonResponse[0]->Code === 323) {
+        if (is_array($jsonResponse) && isset($jsonResponse[0]) && isset($jsonResponse[0]->Code) && $jsonResponse[0]->Code === 323) {
             if ('yes' === $debug) {
                 $this->log->log('error', var_export($jsonResponse[0]->Message, true), array('source' => 'woocommerce-cielo-debit'));
             }

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -17,7 +17,7 @@ use WC_Payment_Gateway;
  */
 
 // Exit if accessed directly.
-if ( ! defined('ABSPATH')) {
+if (! defined('ABSPATH')) {
     exit;
 }
 
@@ -28,7 +28,8 @@ if ( ! defined('ABSPATH')) {
  *
  * @version  1.0.0
  */
-final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
+final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
+{
     /**
      * Define instructions to configure and use this plugin.
      *
@@ -60,7 +61,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
     /**
      * Constructor for the gateway.
      */
-    public function __construct() {
+    public function __construct()
+    {
         $this->id = 'lkn_cielo_debit';
         $this->icon = apply_filters('lkn_wc_cielo_gateway_icon', '');
         $this->has_fields = true;
@@ -107,7 +109,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
     /**
      * Load admin JavaScript for the admin page.
      */
-    public function admin_load_script(): void {
+    public function admin_load_script(): void
+    {
         wp_enqueue_script('lkn-wc-gateway-admin', plugin_dir_url(__FILE__) . '../resources/js/admin/lkn-wc-gateway-admin.js', array('wp-i18n'), $this->version, 'all');
 
         $page = isset($_GET['page']) ? sanitize_text_field(wp_unslash($_GET['page'])) : '';
@@ -142,7 +145,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
     /**
      * Load gateway scripts/styles.
      */
-    public function payment_gateway_scripts(): void {
+    public function payment_gateway_scripts(): void
+    {
         // Don't load scripts outside payment page
         if (
             ! is_checkout()
@@ -188,7 +192,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
     /**
      * Initialise Gateway Settings Form Fields.
      */
-    public function init_form_fields(): void {
+    public function init_form_fields(): void
+    {
         $this->form_fields = array(
             'general' => array(
                 'title' => esc_attr__('General', 'lkn-wc-gateway-cielo'),
@@ -375,7 +380,7 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
 
         $customConfigs = apply_filters('lkn_wc_cielo_get_custom_configs', array(), $this->id);
 
-        if ( ! empty($customConfigs)) {
+        if (! empty($customConfigs)) {
             $this->form_fields = array_merge($this->form_fields, $customConfigs);
         }
     }
@@ -383,7 +388,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
     /**
      * Generate Cielo API 3.0 in auth token.
      */
-    public function generate_debit_auth_token() {
+    public function generate_debit_auth_token()
+    {
         try {
             $env = $this->get_option('env');
             $clientId = $this->get_option('client_id');
@@ -441,7 +447,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
     /**
      * Calculate the total value of items in the WooCommerce cart.
      */
-    public static function lknGetCartTotal() {
+    public static function lknGetCartTotal()
+    {
         $cart = WC()->cart;
 
         if (empty($cart)) {
@@ -459,20 +466,21 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
         return 0;
     }
 
-    private function get_client_ip() {
+    private function get_client_ip()
+    {
         $ip_address = '';
         $client_ip = isset($_SERVER['HTTP_CLIENT_IP']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_CLIENT_IP'])) : '';
         $forwarded_ip = isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_X_FORWARDED_FOR'])) : '';
         $real_ip = isset($_SERVER['HTTP_X_REAL_IP']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_X_REAL_IP'])) : '';
         $remote_ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
 
-        if ( ! empty($client_ip)) {
+        if (! empty($client_ip)) {
             $ip_address = $client_ip;
-        } elseif ( ! empty($forwarded_ip)) {
+        } elseif (! empty($forwarded_ip)) {
             // Se estiver atrás de um proxy, `HTTP_X_FORWARDED_FOR` pode conter uma lista de IPs.
             $ip_list = explode(',', $forwarded_ip);
             $ip_address = trim($ip_list[0]); // Pega o primeiro IP da lista
-        } elseif ( ! empty($real_ip)) {
+        } elseif (! empty($real_ip)) {
             $ip_address = $real_ip;
         } else {
             $ip_address = $remote_ip;
@@ -484,7 +492,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
     /**
      * Render the payment fields.
      */
-    public function payment_fields(): void {
+    public function payment_fields(): void
+    {
         $total_cart = number_format($this->get_order_total(), 2, '', '');
         $accessToken = $this->accessToken;
         $url = get_page_link();
@@ -987,11 +996,12 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
      *
      * @return bool
      */
-    public function validate_fields() {
+    public function validate_fields()
+    {
         $validateCompatMode = $this->get_option('input_validation_compatibility', 'no');
         $nonce = isset($_POST['nonce_lkn_cielo_debit']) ? sanitize_text_field(wp_unslash($_POST['nonce_lkn_cielo_debit'])) : '';
 
-        if ( ! wp_verify_nonce($nonce, 'nonce_lkn_cielo_debit')) {
+        if (! wp_verify_nonce($nonce, 'nonce_lkn_cielo_debit')) {
             $this->log->log('error', 'Nonce verification failed. Nonce: ' . var_export($nonce, true), array('source' => 'woocommerce-cielo-debit'));
             $this->add_notice_once(__('Nonce verification failed, try reloading the page', 'lkn-wc-gateway-cielo'), 'error');
             return false;
@@ -1022,11 +1032,12 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
      *
      * @return array
      */
-    public function process_payment($order_id) {
+    public function process_payment($order_id)
+    {
         $nonceInactive = $this->get_option('nonce_compatibility', 'no');
         $nonce = isset($_POST['nonce_lkn_cielo_debit']) ? sanitize_text_field(wp_unslash($_POST['nonce_lkn_cielo_debit'])) : '';
 
-        if ( ! wp_verify_nonce($nonce, 'nonce_lkn_cielo_debit') && 'no' === $nonceInactive) {
+        if (! wp_verify_nonce($nonce, 'nonce_lkn_cielo_debit') && 'no' === $nonceInactive) {
             $this->log->log('error', 'Nonce verification failed. Nonce: ' . var_export($nonce, true), array('source' => 'woocommerce-cielo-debit'));
             $this->add_notice_once(__('Nonce verification failed, try reloading the page', 'lkn-wc-gateway-cielo'), 'error');
             throw new Exception(esc_attr(__('Nonce verification failed, try reloading the page', 'lkn-wc-gateway-cielo')));
@@ -1044,7 +1055,7 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
         $cardName = apply_filters('lkn_wc_cielo_get_cardholder_name', $cardName, $this, $order);
         $cardType = isset($_POST['lkn_cc_type']) ? sanitize_text_field(wp_unslash($_POST['lkn_cc_type'])) : '';
         $installments = 1;
-        
+
         // Authentication parameters
         $xid = isset($_POST['lkn_cielo_3ds_xid']) ? sanitize_text_field(wp_unslash($_POST['lkn_cielo_3ds_xid'])) : '';
         $cavv = isset($_POST['lkn_cielo_3ds_cavv']) ? sanitize_text_field(wp_unslash($_POST['lkn_cielo_3ds_cavv'])) : '';
@@ -1264,6 +1275,18 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
         }
 
         $response = wp_remote_post($url . '1/sales', $args);
+
+        $jsonResponse = json_decode($response['body']);
+
+        if (isset($jsonResponse[0]->Code) && $jsonResponse[0]->Code === 323) {
+            if ('yes' === $debug) {
+                $this->log->log('error', var_export($jsonResponse[0]->Message, true), array('source' => 'woocommerce-cielo-debit'));
+            }
+            $message = __("Bin Query is not enabled and is not linked to the merchant's registration.", 'lkn-wc-gateway-cielo');
+
+            throw new Exception(esc_attr($message));
+        }
+
         /*  throw new Exception(json_encode($args)); */
         if (is_wp_error($response)) {
             if ('yes' === $debug) {
@@ -1358,7 +1381,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
         throw new Exception(esc_attr($message));
     }
 
-    private function validate_card_holder_name($cardName, $renderNotice) {
+    private function validate_card_holder_name($cardName, $renderNotice)
+    {
         if (empty($cardName) || strlen($cardName) < 3) {
             if ($renderNotice) {
                 $this->add_notice_once(__('Card Holder Name is required!', 'lkn-wc-gateway-cielo'), 'error');
@@ -1379,7 +1403,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
      *
      * @return bool
      */
-    public function process_refund($order_id, $amount = null, $reason = '') {
+    public function process_refund($order_id, $amount = null, $reason = '')
+    {
         // Do your refund here. Refund $amount for the order with ID $order_id
         $url = ($this->get_option('env') == 'production') ? 'https://api.cieloecommerce.cielo.com.br/' : 'https://apisandbox.cieloecommerce.cielo.com.br/';
         $merchantId = sanitize_text_field($this->get_option('merchant_id'));
@@ -1423,7 +1448,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
      *
      * @return bool
      */
-    private function validate_card_number($dcnum, $renderNotice) {
+    private function validate_card_number($dcnum, $renderNotice)
+    {
         if (empty($dcnum)) {
             if ($renderNotice) {
                 $this->add_notice_once(__('Debit Card number is required!', 'lkn-wc-gateway-cielo'), 'error');
@@ -1452,7 +1478,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
      *
      * @return bool
      */
-    private function validate_exp_date($expDate, $renderNotice) {
+    private function validate_exp_date($expDate, $renderNotice)
+    {
         if (empty($expDate)) {
             if ($renderNotice) {
                 $this->add_notice_once(__('Expiration date is required!', 'lkn-wc-gateway-cielo'), 'error');
@@ -1490,7 +1517,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
      *
      * @return bool
      */
-    private function validate_cvv($cvv, $renderNotice) {
+    private function validate_cvv($cvv, $renderNotice)
+    {
         if (empty($cvv)) {
             $this->add_notice_once(__('CVV is required!', 'lkn-wc-gateway-cielo'), 'error');
 
@@ -1513,8 +1541,9 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
      * @param string $message
      * @param string $type
      */
-    private function add_notice_once($message, $type): void {
-        if ( ! wc_has_notice($message, $type)) {
+    private function add_notice_once($message, $type): void
+    {
+        if (! wc_has_notice($message, $type)) {
             wc_add_notice($message, $type);
         }
     }
@@ -1526,7 +1555,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway {
      *
      * @return string|bool
      */
-    private function get_card_provider($cardNumber) {
+    private function get_card_provider($cardNumber)
+    {
         $brand = '';
         $brand = apply_filters('lkn_wc_cielo_get_card_brand', $brand, $cardNumber, $this->id);
 

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -1282,7 +1282,7 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
             if ('yes' === $debug) {
                 $this->log->log('error', var_export($jsonResponse[0]->Message, true), array('source' => 'woocommerce-cielo-debit'));
             }
-            $message = __("Bin Query is not enabled and is not linked to the merchant's registration.", 'lkn-wc-gateway-cielo');
+            $message = __("Bin query is not enabled for this merchant.", 'lkn-wc-gateway-cielo');
 
             throw new Exception(esc_attr($message));
         }

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -1,9 +1,10 @@
 <?php
+
 /**
  * Plugin Name: Payment Gateway for Cielo API on WooCommerce
  * Plugin URI: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
  * Description: Adds the Cielo API 3.0 Payments gateway to your WooCommerce website.
- * Version: 1.17.1
+ * Version: 1.17.2
  * Author: Link Nacional
  * Author URI: https://linknacional.com.br
  * Text Domain: lkn-wc-gateway-cielo
@@ -22,7 +23,7 @@ use Lkn\WCCieloPaymentGateway\Includes\LknWcCieloCreditBlocks;
 use Lkn\WCCieloPaymentGateway\Includes\LknWcCieloDebitBlocks;
 
 // Exit if accessed directly.
-if ( ! defined('ABSPATH')) {
+if (! defined('ABSPATH')) {
     exit;
 }
 
@@ -33,13 +34,15 @@ require_once __DIR__ . '/vendor/autoload.php';
  *
  * @class Lkn_WC_Cielo_Payment
  */
-final class LknWCCieloPayment {
+final class LknWCCieloPayment
+{
     /**
      * Show plugin dependency notice.
      *
      * @since
      */
-    public static function __lkn_wc_gateway_cielo_dependency_notice(): void {
+    public static function __lkn_wc_gateway_cielo_dependency_notice(): void
+    {
         // Admin notice.
         $message = sprintf(
             '<strong>%1$s</strong> %2$s <a href="%3$s" target="_blank">%4$s</a>  %5$s %6$s+ %7$s.',
@@ -60,7 +63,8 @@ final class LknWCCieloPayment {
      *
      * @since
      */
-    public static function __lkn_wc_gateway_cielo_inactive_notice(): void {
+    public static function __lkn_wc_gateway_cielo_inactive_notice(): void
+    {
         // Admin notice.
         $message = sprintf(
             '<div class="notice notice-error"><p><strong>%1$s</strong> %2$s <a href="%3$s" target="_blank">%4$s</a> %5$s.</p></div>',
@@ -77,7 +81,8 @@ final class LknWCCieloPayment {
     /**
      * Plugin bootstrapping.
      */
-    public static function init(): void {
+    public static function init(): void
+    {
         add_action('beforewoocommerce_init', array(__CLASS__, 'wcEditorBlocksActive'));
         add_action('woocommerce_blocks_payment_method_type_registration', array(__CLASS__, 'wcEditorBlocksAddPaymentMethod'));
 
@@ -106,13 +111,15 @@ final class LknWCCieloPayment {
         add_action('admin_notices', array(__CLASS__, 'lkn_admin_notice'));
     }
 
-    public static function lkn_admin_notice(): void {
-        if ( ! file_exists(WP_PLUGIN_DIR . '/fraud-detection-for-woocommerce/fraud-detection-for-woocommerce.php') && ! is_plugin_active('integration-rede-for-woocommerce/integration-rede-for-woocommerce.php')) {
+    public static function lkn_admin_notice(): void
+    {
+        if (! file_exists(WP_PLUGIN_DIR . '/fraud-detection-for-woocommerce/fraud-detection-for-woocommerce.php') && ! is_plugin_active('integration-rede-for-woocommerce/integration-rede-for-woocommerce.php')) {
             require LKN_WC_GATEWAY_CIELO_DIR . 'includes/views/notices/LknWcCieloDownloadNotice.php';
         }
     }
 
-    public static function wcEditorBlocksActive(): void {
+    public static function wcEditorBlocksActive(): void
+    {
         if (class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
             Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
                 'cart_checkout_blocks',
@@ -122,8 +129,9 @@ final class LknWCCieloPayment {
         }
     }
 
-    public static function wcEditorBlocksAddPaymentMethod(Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry): void {
-        if ( ! class_exists('Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType')) {
+    public static function wcEditorBlocksAddPaymentMethod(Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry): void
+    {
+        if (! class_exists('Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType')) {
             return;
         }
 
@@ -138,14 +146,15 @@ final class LknWCCieloPayment {
      *
      * @since
      */
-    public static function check_environment() {
+    public static function check_environment()
+    {
         // Is not admin
-        if ( ! is_admin() || ! current_user_can('activate_plugins')) {
+        if (! is_admin() || ! current_user_can('activate_plugins')) {
             return null;
         }
 
         // Load plugin helper functions.
-        if ( ! function_exists('deactivate_plugins') || ! function_exists('is_plugin_active')) {
+        if (! function_exists('deactivate_plugins') || ! function_exists('is_plugin_active')) {
             require_once ABSPATH . '/wp-admin/includes/plugin.php';
         }
 
@@ -164,14 +173,14 @@ final class LknWCCieloPayment {
                     $is_installed = ! empty($all_plugins['woocommerce/woocommerce.php']);
                 }
 
-                if ( ! $is_installed) {
+                if (! $is_installed) {
                     add_action('admin_notices', array(__CLASS__, '__lkn_wc_gateway_cielo_dependency_notice'));
                 }
 
                 // Check for if give plugin activate or not.
                 $is_wc_active = class_exists('WooCommerce');
 
-                if ( ! $is_wc_active) {
+                if (! $is_wc_active) {
                     add_action('admin_notices', array(__CLASS__, '__lkn_wc_gateway_cielo_inactive_notice'));
 
                     $is_deactivate_plugin = true;
@@ -201,7 +210,8 @@ final class LknWCCieloPayment {
      * @param array
      * @param mixed $gateways
      */
-    public static function add_gateway($gateways) {
+    public static function add_gateway($gateways)
+    {
         $gateways[] = new LknWCGatewayCieloCredit();
         $gateways[] = new LknWCGatewayCieloDebit();
 
@@ -211,7 +221,8 @@ final class LknWCCieloPayment {
     /**
      * Plugin includes.
      */
-    public static function includes(): void {
+    public static function includes(): void
+    {
         LknWCCieloPayment::setup_constants();
         LknWCCieloPayment::check_environment();
     }
@@ -221,7 +232,8 @@ final class LknWCCieloPayment {
      *
      * @return string
      */
-    public static function plugin_url() {
+    public static function plugin_url()
+    {
         return untrailingslashit(plugins_url('/', __FILE__));
     }
 
@@ -230,7 +242,8 @@ final class LknWCCieloPayment {
      *
      * @return string
      */
-    public static function plugin_abspath() {
+    public static function plugin_abspath()
+    {
         return trailingslashit(plugin_dir_path(__FILE__));
     }
 
@@ -244,7 +257,8 @@ final class LknWCCieloPayment {
      *
      * @return array
      */
-    public static function lkn_wc_cielo_plugin_row_meta($plugin_meta, $plugin_file) {
+    public static function lkn_wc_cielo_plugin_row_meta($plugin_meta, $plugin_file)
+    {
         $new_meta_links['setting'] = sprintf(
             '<a href="%1$s">%2$s</a>',
             admin_url('admin.php?page=wc-settings&tab=checkout'),
@@ -254,7 +268,8 @@ final class LknWCCieloPayment {
         return array_merge($plugin_meta, $new_meta_links);
     }
 
-    public static function lkn_wc_cielo_plugin_row_meta_pro($plugin_meta, $plugin_file) {
+    public static function lkn_wc_cielo_plugin_row_meta_pro($plugin_meta, $plugin_file)
+    {
         // Defina o URL e o texto do link
         $url = 'https://www.linknacional.com.br/wordpress/woocommerce/cielo/';
         $link_text = sprintf(
@@ -276,7 +291,8 @@ final class LknWCCieloPayment {
      *
      * @param WC_Order $order
      */
-    public static function order_details_after_order_table($order): void {
+    public static function order_details_after_order_table($order): void
+    {
         $installment = $order->get_meta('installments');
 
         if ($installment && $installment > 1) {
@@ -291,7 +307,8 @@ final class LknWCCieloPayment {
      * @param bool     $sent_to_admin
      * @param WC_Order $order
      */
-    public static function email_order_meta_fields($fields, $sent_to_admin, $order) {
+    public static function email_order_meta_fields($fields, $sent_to_admin, $order)
+    {
         $installment = $order->get_meta('installments');
         if ($installment && $installment > 1) {
             $fields['installment'] = array(
@@ -306,24 +323,25 @@ final class LknWCCieloPayment {
     /**
      * Setup plugin constants for ease of use.
      */
-    private static function setup_constants(): void {
+    private static function setup_constants(): void
+    {
         // Defines addon version number for easy reference.
-        if ( ! defined('LKN_WC_CIELO_VERSION')) {
-            define('LKN_WC_CIELO_VERSION', '1.17.1');
+        if (! defined('LKN_WC_CIELO_VERSION')) {
+            define('LKN_WC_CIELO_VERSION', '1.17.2');
         }
-        if ( ! defined('LKN_WC_CIELO_TRANSLATION_PATH')) {
+        if (! defined('LKN_WC_CIELO_TRANSLATION_PATH')) {
             define('LKN_WC_CIELO_TRANSLATION_PATH', plugin_dir_path(__FILE__) . 'languages/');
         }
-        if ( ! defined('LKN_WC_GATEWAY_CIELO_BASENAME')) {
+        if (! defined('LKN_WC_GATEWAY_CIELO_BASENAME')) {
             define('LKN_WC_GATEWAY_CIELO_BASENAME', plugin_basename(__FILE__));
         }
-        if ( ! defined('LKN_WC_GATEWAY_CIELO_DIR')) {
+        if (! defined('LKN_WC_GATEWAY_CIELO_DIR')) {
             define('LKN_WC_GATEWAY_CIELO_DIR', plugin_dir_path(__FILE__));
         }
-        if ( ! defined('LKN_WC_GATEWAY_CIELO_URL')) {
+        if (! defined('LKN_WC_GATEWAY_CIELO_URL')) {
             define('LKN_WC_GATEWAY_CIELO_URL', plugin_dir_url(__FILE__));
         }
-        if ( ! defined('LKN_WC_GATEWAY_CIELO_MIN_WC_VERSION')) {
+        if (! defined('LKN_WC_GATEWAY_CIELO_MIN_WC_VERSION')) {
             define('LKN_WC_GATEWAY_CIELO_MIN_WC_VERSION', '5.0.0');
         }
     }

--- a/resources/js/frontend/lkn-cc-installment.js
+++ b/resources/js/frontend/lkn-cc-installment.js
@@ -39,7 +39,7 @@
 
       for (let i = 1; i <= lknInstallmentLimit; i++) {
         const installment = amount / i
-        const formatedInstallment = new Intl.NumberFormat('pt-br', { style: 'currency', currency: 'BRL' }).format(installment)
+        const formatedInstallment = new Intl.NumberFormat('pt-br', { style: 'currency', currency: lknWCCieloCredit.currency }).format(installment)
         const option = document.createElement('option')
         let text = document.createTextNode(i + 'x ' + formatedInstallment + ' sem juros')
         if (lknWCCieloCredit.licenseResult) {
@@ -51,7 +51,7 @@
                 text = document.createTextNode(installmentObj.label)
               } else {
                 const interest = (amount + (amount * (installmentObj.interest / 100))) / i // installment + (installment * (installmentObj.interest / 100));
-                const formatedInterest = new Intl.NumberFormat('pt-br', { style: 'currency', currency: 'BRL' }).format(interest)
+                const formatedInterest = new Intl.NumberFormat('pt-br', { style: 'currency', currency: lknWCCieloCredit.currency }).format(interest)
 
                 text = document.createTextNode(i + 'x ' + formatedInterest)
               }


### PR DESCRIPTION
# Payment Gateway for Cielo API on WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, payment, paymethod, card, credit

Testado até: 6.7.1

Versão estável: 1.17.2

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil)

O **Gateway de Pagamento API Cielo para WooCommerce** é um plugin que integra sua loja WooCommerce à Cielo, permitindo pagamentos com **cartões de crédito** e **débito**, com **suporte a 3DS**, proporcionando transações seguras e rápidas.

## Descrição

O **Gateway de Pagamento API Cielo para WooCommerce** é um plugin de pagamento para WooCommerce que permite integrar sua loja online com a Cielo, uma das principais soluções de pagamento do Brasil. Com este plugin, você pode oferecer aos seus clientes a possibilidade de pagar com **cartões de crédito** e **débito**, com **suporte a 3DS**, garantindo transações seguras e rápidas.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin wc_cielo_payment_gateway também está ativado.
6. OBS: é necessário possuir uma licença da LinkNacional valida para habilitar os recursos disponíveis. 

## Resumo(1.17.2):

> Validação da opção de cartão online no momento do pagamento:

![image](https://github.com/user-attachments/assets/b3cc3657-a157-43fa-8218-e063bf5f52f1)

- Correção de exibição de moeda nas parcelas
> Ajustada a exibição da moeda nas parcelas, que anteriormente mostrava "R$" mesmo quando o pagamento era em dólares nas faturas.
![image](https://github.com/user-attachments/assets/3af05637-0422-4bc9-af4c-929f7ed0beca)
