### PR TITLE
1.19.0 - wc_cielo_payment_gateway (Correção de scripts duplicados)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: "1.18.1"
+        custom_tag: "1.19.0"
 
     # Generate new release
     - name: Generate new Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: "1.18.0"
+        custom_tag: "1.18.1"
 
     # Generate new release
     - name: Generate new Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.18.1 - 20/03/2025
+* Correção de scripts duplicados.
+
 # 1.18.0 - 17/03/2025
 * Método de pagamento pix.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-# 1.18.1 - 20/03/2025
+# 1.19.0 - 20/03/2025
+* Adição de mensagem para informar quando as credenciais estão erradas;
 * Correção de scripts duplicados.
 
 # 1.18.0 - 17/03/2025

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
 Tags: woocommerce, payment, paymethod, card, credit
 Requires at least: 5.7
 Tested up to: 6.7
-Stable tag: 1.18.0
+Stable tag: 1.18.1
 Requires PHP: 7.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -98,6 +98,10 @@ This plugin uses the [React Credit Cards](https://github.com/amaroteam/react-cre
 7. Debit card front page with payment fields.
 
 == Changelog ==
+= 1.18.1 =
+**20/03/2025**
+* Duplicate scripts.
+
 = 1.18.0 =
 **17/03/2025**
 * Payment method Pix.

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
 Tags: woocommerce, payment, paymethod, card, credit
 Requires at least: 5.7
 Tested up to: 6.7
-Stable tag: 1.18.1
+Stable tag: 1.19.0
 Requires PHP: 7.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -100,6 +100,7 @@ This plugin uses the [React Credit Cards](https://github.com/amaroteam/react-cre
 == Changelog ==
 = 1.18.1 =
 **20/03/2025**
+* Add message to inform when credentials are incorrect;
 * Duplicate scripts.
 
 = 1.18.0 =

--- a/includes/LknWCGatewayCieloCredit.php
+++ b/includes/LknWCGatewayCieloCredit.php
@@ -90,9 +90,6 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway
         // Actions.
         add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
 
-        // Action hook to load custom JavaScript
-        add_action('wp_enqueue_scripts', array($this, 'payment_gateway_scripts'));
-
         add_action('woocommerce_scheduled_subscription_payment_' . $this->id, array($this, 'process_subscription_payment'), 10, 3);
 
         // Action hook to load admin JavaScript
@@ -134,6 +131,12 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway
             ));
         }
 
+    }
+
+    public function initialize_payment_gateway_scripts()
+    {
+        // Aqui você pode adicionar o hook manualmente dentro da função
+        add_action('wp_enqueue_scripts', [$this, 'payment_gateway_scripts']);
     }
 
     /**

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -98,13 +98,13 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
         // Actions.
         add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
 
-        add_action('wp_enqueue_scripts', array($this, 'payment_gateway_scripts'));
-
         // Action hook to load admin JavaScript
         if (function_exists('get_plugins')) {
             add_action('admin_enqueue_scripts', array($this, 'admin_load_script'));
         }
     }
+
+
 
     /**
      * Load admin JavaScript for the admin page.
@@ -127,6 +127,12 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
             ));
         }
 
+    }
+
+    public function initialize_payment_gateway_scripts()
+    {
+        // Aqui você pode adicionar o hook manualmente dentro da função
+        add_action('wp_enqueue_scripts', [$this, 'payment_gateway_scripts']);
     }
 
     /**

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -1291,6 +1291,11 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
             throw new Exception(esc_attr($message));
         }
         $responseDecoded = json_decode($response['body']);
+
+        if (isset($responseDecoded->Code) && isset($responseDecoded->Message)) {
+            throw new Exception(esc_attr($responseDecoded->Message));
+        }
+
         if ($this->get_option('debug') === 'yes') {
             $lknWcCieloHelper = new LknWcCieloHelper();
 

--- a/includes/LknWcCieloCreditBlocks.php
+++ b/includes/LknWcCieloCreditBlocks.php
@@ -5,20 +5,26 @@ namespace Lkn\WCCieloPaymentGateway\Includes;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
 use Lkn\WCCieloPaymentGateway\Includes\LknWCGatewayCieloCredit;
 
-final class LknWcCieloCreditBlocks extends AbstractPaymentMethodType {
+final class LknWcCieloCreditBlocks extends AbstractPaymentMethodType
+{
     private $gateway;
     protected $name = 'lkn_cielo_credit';
 
-    public function initialize(): void {
+    public function initialize(): void
+    {
         $this->settings = get_option('woocommerce_lkn_cielo_credit_settings', array());
-        $this->gateway = new LknWCGatewayCieloCredit();
+        $lknWcGateWayCieloCredit = new LknWCGatewayCieloCredit();
+        $lknWcGateWayCieloCredit->initialize_payment_gateway_scripts();
+        $this->gateway = $lknWcGateWayCieloCredit;
     }
 
-    public function is_active() {
+    public function is_active()
+    {
         return $this->gateway->is_available();
     }
 
-    public function get_payment_method_script_handles() {
+    public function get_payment_method_script_handles()
+    {
         wp_register_script(
             'lkn_cielo_credit-blocks-integration',
             plugin_dir_url(__FILE__) . '../resources/js/creditCard/lknCieloCreditCompiled.js',
@@ -40,7 +46,8 @@ final class LknWcCieloCreditBlocks extends AbstractPaymentMethodType {
         return array('lkn_cielo_credit-blocks-integration');
     }
 
-    public function get_payment_method_data() {
+    public function get_payment_method_data()
+    {
         $installmentLimit = $this->gateway->get_option('installment_limit', 12);
         $installments = array();
 

--- a/includes/LknWcCieloDebitBlocks.php
+++ b/includes/LknWcCieloDebitBlocks.php
@@ -103,8 +103,8 @@ final class LknWcCieloDebitBlocks extends AbstractPaymentMethodType
         return array(
             'title' => $this->gateway->title,
             'description' => $this->gateway->description,
-            'accessToken' => $acessToken['access_token'] ? $acessToken['access_token'] : '',
-            'accessTokenExpiration' => $acessToken['expires_in'] ? $acessToken['expires_in'] : '',
+            'accessToken' => isset($acessToken['access_token']) ? $acessToken['access_token'] : '',
+            'accessTokenExpiration' => isset($acessToken['expires_in']) ? $acessToken['expires_in'] : '',
             'url' => get_page_link(),
             'orderNumber' => uniqid(),
             'activeInstallment' => $this->gateway->get_option('installment_payment'),

--- a/includes/LknWcCieloDebitBlocks.php
+++ b/includes/LknWcCieloDebitBlocks.php
@@ -5,23 +5,27 @@ namespace Lkn\WCCieloPaymentGateway\Includes;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
 use Lkn\WCCieloPaymentGateway\Includes\LknWCGatewayCieloDebit;
 
-final class LknWcCieloDebitBlocks extends AbstractPaymentMethodType {
+final class LknWcCieloDebitBlocks extends AbstractPaymentMethodType
+{
     private $gateway;
     protected $name = 'lkn_cielo_debit';
 
-    public function initialize(): void {
-        $this->settings = get_option( 'woocommerce_lkn_cielo_debit_settings', array() );
+    public function initialize(): void
+    {
+        $this->settings = get_option('woocommerce_lkn_cielo_debit_settings', array());
         $this->gateway = new LknWCGatewayCieloDebit();
     }
 
-    public function is_active() {
+    public function is_active()
+    {
         return $this->gateway->is_available();
     }
 
-    public function get_payment_method_script_handles() {
+    public function get_payment_method_script_handles()
+    {
         wp_register_script(
             'lkn_cielo_debit-blocks-integration',
-            plugin_dir_url( __FILE__ ) . '../resources/js/debitCard/lknCieloDebitCompiled.js',
+            plugin_dir_url(__FILE__) . '../resources/js/debitCard/lknCieloDebitCompiled.js',
             array(
                 'wc-blocks-registry',
                 'wc-settings',
@@ -33,28 +37,29 @@ final class LknWcCieloDebitBlocks extends AbstractPaymentMethodType {
             '1.0.0',
             true
         );
-        if ( function_exists( 'wp_set_script_translations' ) ) {
-            wp_set_script_translations( 'lkn_cielo_debit-blocks-integration');
+        if (function_exists('wp_set_script_translations')) {
+            wp_set_script_translations('lkn_cielo_debit-blocks-integration');
         }
 
         do_action('lkn_wc_cielo_remove_cardholder_name_3ds', $this->gateway);
         return array('lkn_cielo_debit-blocks-integration');
     }
 
-    private function get_client_ip() {
+    private function get_client_ip()
+    {
         $ip_address = '';
         $client_ip = isset($_SERVER['HTTP_CLIENT_IP']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_CLIENT_IP'])) : '';
         $forwarded_ip = isset($_SERVER['HTTP_X_FORWARDED_FOR']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_X_FORWARDED_FOR'])) : '';
         $real_ip = isset($_SERVER['HTTP_X_REAL_IP']) ? sanitize_text_field(wp_unslash($_SERVER['HTTP_X_REAL_IP'])) : '';
         $remote_ip = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : '';
 
-        if ( ! empty($client_ip)) {
+        if (! empty($client_ip)) {
             $ip_address = $client_ip;
-        } elseif ( ! empty($forwarded_ip)) {
+        } elseif (! empty($forwarded_ip)) {
             // Se estiver atrás de um proxy, `HTTP_X_FORWARDED_FOR` pode conter uma lista de IPs.
             $ip_list = explode(',', $forwarded_ip);
             $ip_address = trim($ip_list[0]); // Pega o primeiro IP da lista
-        } elseif ( ! empty($real_ip)) {
+        } elseif (! empty($real_ip)) {
             $ip_address = $real_ip;
         } else {
             $ip_address = $remote_ip;
@@ -63,7 +68,8 @@ final class LknWcCieloDebitBlocks extends AbstractPaymentMethodType {
         return $ip_address;
     }
 
-    public function get_payment_method_data() {
+    public function get_payment_method_data()
+    {
         if ($this->gateway->get_option('env') == 'sandbox') {
             $dirScriptConfig3DS = LKN_WC_GATEWAY_CIELO_URL . 'resources/js/debitCard/lkn-dc-script-sdb.js';
         } else {
@@ -103,7 +109,7 @@ final class LknWcCieloDebitBlocks extends AbstractPaymentMethodType {
             'dirScript3DS' => LKN_WC_GATEWAY_CIELO_URL . 'resources/js/debitCard/BP.Mpi.3ds20.min.js',
             'dirScriptConfig3DS' => $dirScriptConfig3DS,
             'totalCart' => $this->gateway->lknGetCartTotal(),
-            'nonceCieloDebit' => wp_create_nonce( 'nonce_lkn_cielo_debit' ),
+            'nonceCieloDebit' => wp_create_nonce('nonce_lkn_cielo_debit'),
             'installmentLimit' => $installmentLimit,
             'installments' => $installments,
             'installmentMinAmount' => $installmentMinAmount,

--- a/includes/LknWcCieloDebitBlocks.php
+++ b/includes/LknWcCieloDebitBlocks.php
@@ -103,8 +103,8 @@ final class LknWcCieloDebitBlocks extends AbstractPaymentMethodType
         return array(
             'title' => $this->gateway->title,
             'description' => $this->gateway->description,
-            'accessToken' => $acessToken['access_token'],
-            'accessTokenExpiration' => $acessToken['expires_in'],
+            'accessToken' => $acessToken['access_token'] ? $acessToken['access_token'] : '',
+            'accessTokenExpiration' => $acessToken['expires_in'] ? $acessToken['expires_in'] : '',
             'url' => get_page_link(),
             'orderNumber' => uniqid(),
             'activeInstallment' => $this->gateway->get_option('installment_payment'),

--- a/includes/LknWcCieloDebitBlocks.php
+++ b/includes/LknWcCieloDebitBlocks.php
@@ -13,7 +13,9 @@ final class LknWcCieloDebitBlocks extends AbstractPaymentMethodType
     public function initialize(): void
     {
         $this->settings = get_option('woocommerce_lkn_cielo_debit_settings', array());
-        $this->gateway = new LknWCGatewayCieloDebit();
+        $lknWcGateWayCieloDebit = new LknWCGatewayCieloDebit();
+        $lknWcGateWayCieloDebit->initialize_payment_gateway_scripts();
+        $this->gateway = $lknWcGateWayCieloDebit;
     }
 
     public function is_active()

--- a/includes/LknWcCieloRequest.php
+++ b/includes/LknWcCieloRequest.php
@@ -38,12 +38,8 @@ final class LknWcCieloRequest
                 'IdentityType' => $billingCpfCpnj['IdentityType'],
             ),
             'Payment' => array(
-                'Type' => 'qrcode',
-                'Amount' => $amount,
-                'Provider' => 'Cielo',
-                'Installments' => 1,
-                'Modality' => 'Pix',
-                'Capture' => false
+                'Type' => 'Pix',
+                'Amount' => $amount
             )
         );
 
@@ -58,19 +54,6 @@ final class LknWcCieloRequest
             'headers' => $header,
             'timeout' => 60,
         ));
-
-        // Registrar o log completo com os dados mascarados
-        if ('yes' == $instance->debug) {
-            $this->log->log('info', 'pixRequest', array(
-                'request' => array(
-                    'url' => $postUrl . '/1/sales/',
-                    'current_time' => current_time('mysql'),
-                    'body' => $body,
-                    'header' => $header,
-                ),
-                'response' => $response
-            ));
-        }
 
         if (is_wp_error($response)) {
             return array(
@@ -124,6 +107,19 @@ final class LknWcCieloRequest
         // Da mesma forma, mascarar os campos sensíveis do header
         $header['MerchantId'] = $this->maskSensitiveData($header['MerchantId']);
         $header['MerchantKey'] = $this->maskSensitiveData($header['MerchantKey']);
+
+        // Registrar o log completo com os dados mascarados
+        if ('yes' == $instance->debug) {
+            $this->log->log('info', 'pixRequest', array(
+                'request' => array(
+                    'url' => $postUrl . '/1/sales/',
+                    'current_time' => current_time('mysql'),
+                    'body' => $body,
+                    'header' => $header,
+                ),
+                'response' => $response
+            ));
+        }
 
         return array(
             'sucess' => true,

--- a/includes/LknWcCieloRequest.php
+++ b/includes/LknWcCieloRequest.php
@@ -38,8 +38,12 @@ final class LknWcCieloRequest
                 'IdentityType' => $billingCpfCpnj['IdentityType'],
             ),
             'Payment' => array(
-                'Type' => 'Pix',
-                'Amount' => $amount
+                'Type' => 'qrcode',
+                'Amount' => $amount,
+                'Provider' => 'Cielo',
+                'Installments' => 1,
+                'Modality' => 'Pix',
+                'Capture' => false
             )
         );
 

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -4,7 +4,7 @@
  * Plugin Name: Payment Gateway for Cielo API on WooCommerce
  * Plugin URI: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
  * Description: Adds the Cielo API 3.0 Payments gateway to your WooCommerce website.
- * Version: 1.18.1
+ * Version: 1.19.0
  * Author: Link Nacional
  * Author URI: https://linknacional.com.br
  * Text Domain: lkn-wc-gateway-cielo
@@ -333,7 +333,7 @@ final class LknWCCieloPayment
     {
         // Defines addon version number for easy reference.
         if (! defined('LKN_WC_CIELO_VERSION')) {
-            define('LKN_WC_CIELO_VERSION', '1.18.1');
+            define('LKN_WC_CIELO_VERSION', '1.19.0');
         }
         if (! defined('LKN_WC_CIELO_TRANSLATION_PATH')) {
             define('LKN_WC_CIELO_TRANSLATION_PATH', plugin_dir_path(__FILE__) . 'languages/');

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -217,14 +217,8 @@ final class LknWCCieloPayment
      */
     public static function add_gateway($gateways)
     {
-        $lknWcGateWayCieloCredit = new LknWCGatewayCieloCredit();
-        $lknWcGateWayCieloCredit->initialize_payment_gateway_scripts();
-        $gateways[] = $lknWcGateWayCieloCredit;
-
-        $lknWcGateWayCieloDebit = new LknWCGatewayCieloDebit();
-        $lknWcGateWayCieloDebit->initialize_payment_gateway_scripts();
-        $gateways[] = $lknWcGateWayCieloDebit;
-
+        $gateways[] = new LknWCGatewayCieloCredit();
+        $gateways[] = new LknWCGatewayCieloDebit();
         $gateways[] = new LknWcCieloPix();
 
         return $gateways;

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -4,7 +4,7 @@
  * Plugin Name: Payment Gateway for Cielo API on WooCommerce
  * Plugin URI: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
  * Description: Adds the Cielo API 3.0 Payments gateway to your WooCommerce website.
- * Version: 1.18.0
+ * Version: 1.18.1
  * Author: Link Nacional
  * Author URI: https://linknacional.com.br
  * Text Domain: lkn-wc-gateway-cielo
@@ -339,7 +339,7 @@ final class LknWCCieloPayment
     {
         // Defines addon version number for easy reference.
         if (! defined('LKN_WC_CIELO_VERSION')) {
-            define('LKN_WC_CIELO_VERSION', '1.18.0');
+            define('LKN_WC_CIELO_VERSION', '1.18.1');
         }
         if (! defined('LKN_WC_CIELO_TRANSLATION_PATH')) {
             define('LKN_WC_CIELO_TRANSLATION_PATH', plugin_dir_path(__FILE__) . 'languages/');

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -217,8 +217,14 @@ final class LknWCCieloPayment
      */
     public static function add_gateway($gateways)
     {
-        $gateways[] = new LknWCGatewayCieloCredit();
-        $gateways[] = new LknWCGatewayCieloDebit();
+        $lknWcGateWayCieloCredit = new LknWCGatewayCieloCredit();
+        $lknWcGateWayCieloCredit->initialize_payment_gateway_scripts();
+        $gateways[] = $lknWcGateWayCieloCredit;
+
+        $lknWcGateWayCieloDebit = new LknWCGatewayCieloDebit();
+        $lknWcGateWayCieloDebit->initialize_payment_gateway_scripts();
+        $gateways[] = $lknWcGateWayCieloDebit;
+
         $gateways[] = new LknWcCieloPix();
 
         return $gateways;

--- a/resources/js/admin/lkn-wc-gateway-admin-layout.js
+++ b/resources/js/admin/lkn-wc-gateway-admin-layout.js
@@ -139,6 +139,7 @@
 
       const hrElement = document.createElement('hr')
       divElement.parentElement.insertBefore(hrElement, divElement.nextSibling)
+      lknWcCieloValidateMerchantInputs()
     }
 
     const message = $('<p id="footer-left" class="alignleft"></p>')
@@ -158,4 +159,46 @@
       $('#footer-left').html('Obrigado :)').css('text-align', 'center')
     })
   })
+
+  function lknWcCieloValidateMerchantInputs() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const sectionParam = urlParams.get("section");
+
+    if(sectionParam){
+      const merchantIdInput = document.querySelector(`#woocommerce_${sectionParam}_merchant_id`);
+      const merchantKeyInput = document.querySelector(`#woocommerce_${sectionParam}_merchant_key`);
+      
+      if(merchantIdInput && merchantKeyInput){
+        function validateInput(input, expectedLength, message) {
+            const parent = input.parentElement;
+            let errorMsg = parent.querySelector(".validation-error");
+    
+            if (input.value.length !== expectedLength) {
+                if (!errorMsg) {
+                    errorMsg = document.createElement("p");
+                    errorMsg.className = "validation-error";
+                    errorMsg.style.color = "red";
+                    errorMsg.style.fontWeight = "500";
+                    errorMsg.style.marginTop = "5px";
+                    errorMsg.style.fontSize = "small";
+                    parent.appendChild(errorMsg);
+                }
+                errorMsg.textContent = message;
+            } else {
+                if (errorMsg) errorMsg.remove();
+            }
+        }
+    
+        function validateFields() {
+            validateInput(merchantIdInput, 36, "O Merchant ID deve ter 36 caracteres.");
+            validateInput(merchantKeyInput, 40, "A Merchant Key deve ter 40 caracteres.");
+        }
+    
+        merchantIdInput.addEventListener("input", validateFields);
+        merchantKeyInput.addEventListener("input", validateFields);
+    
+        validateFields(); // Valida ao carregar a página
+      }
+    }
+  }
 })(jQuery)


### PR DESCRIPTION
# Payment Gateway for Cielo API on WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: payment, paymethod, card, credit

Testado até: 6.7.1

Versão estável: 1.19.0

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil)

## Descrição

A Cielo API Payment Gateway for WooCommerce é um plugin de pagamento para WooCommerce que permite integrar sua loja online com a Cielo, uma das principais soluções de pagamento do Brasil. Com este plugin, você pode oferecer aos seus clientes a possibilidade de pagar com cartões de crédito e débito, com suporte a 3DS, garantindo transações seguras e rápidas.

O plugin é fácil de configurar e permite o uso dos principais cartões aceitos pela Cielo, integrando-se de forma nativa com o WooCommerce e simplificando a experiência de checkout em sua loja.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## Resumo(1.19.0):

> Correção de script duplicados ao carregar um gateway de pagamento.
![image](https://github.com/user-attachments/assets/e9d0f53f-67c7-4098-abeb-dd37aaddc0f5)

> Adição de mensagem para informar quando as credenciais estão erradas.
![image](https://github.com/user-attachments/assets/9e8e2abf-7e59-4275-9640-a30eca12541c)
