### PR TITLE
1.21.3 - wc_cielo_payment_gateway (AJustes finais)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "1.21.2"
+  DEPLOY_TAG: "1.21.3"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "1.21.1"
+  DEPLOY_TAG: "1.21.3"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+# 1.21.3 - 18/06/2025
+* Correção ajustes finais.
+
 # 1.21.2 - 16/06/2025
 * Adição de novo layout para página de configuração(new version).
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
 Tags: woocommerce, payment, paymethod, card, credit
 Requires at least: 5.7
 Tested up to: 6.8
-Stable tag: 1.21.2
+Stable tag: 1.21.3
 Requires PHP: 7.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/README.txt
+++ b/README.txt
@@ -100,6 +100,10 @@ This plugin uses the [React Credit Cards](https://github.com/amaroteam/react-cre
 7. Debit card front page with payment fields.
 
 == Changelog ==
+= 1.21.3 =
+** 18/06/2025**
+* Fix final adjustments.
+
 = 1.21.2 =
 ** 16/06/2025**
 * Addition of new layout for the settings page(new version).

--- a/includes/LknWCGatewayCieloCredit.php
+++ b/includes/LknWCGatewayCieloCredit.php
@@ -263,19 +263,6 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway
                     'data-title-description' => __('This is your secret Merchant Key used to sign transactions with Cielo API. Keep it safe and do not share.', 'lkn-wc-gateway-cielo')
                 )
             ),
-            'invoiceDesc' => array(
-                'title'       => __('Invoice Description', 'lkn-wc-gateway-cielo'),
-                'type'        => 'text',
-                'default'     => __('order', 'lkn-wc-gateway-cielo'),
-                'description' => __('Invoice description that the customer will see on your checkout (special characters are not accepted).', 'lkn-wc-gateway-cielo'),
-                'desc_tip'    => __('Enter a brief description that will appear on the customer invoice.', 'lkn-wc-gateway-cielo'),
-                'custom_attributes' => array(
-                    'maxlength' => 50,
-                    'pattern'   => '[a-zA-Z]+( [a-zA-Z]+)*',
-                    'required'  => 'required',
-                    'data-title-description' => __('This description will be used on the transaction invoice. It should be readable and not contain special characters or numbers.', 'lkn-wc-gateway-cielo')
-                )
-            ),
             'env' => array(
                 'title'       => __('Environment', 'lkn-wc-gateway-cielo'),
                 'type'        => 'select',
@@ -287,6 +274,19 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway
                 'desc_tip'  => __('Choose between production or development mode for Cielo API.', 'lkn-wc-gateway-cielo'),
                 'custom_attributes' => array(
                     'data-title-description' => __('Select "Development" to test transactions in sandbox mode. Use "Production" for real transactions.', 'lkn-wc-gateway-cielo')
+                )
+            ),
+            'invoiceDesc' => array(
+                'title'       => __('Invoice Description', 'lkn-wc-gateway-cielo'),
+                'type'        => 'text',
+                'default'     => __('order', 'lkn-wc-gateway-cielo'),
+                'description' => __('Invoice description that the customer will see on your checkout (special characters are not accepted).', 'lkn-wc-gateway-cielo'),
+                'desc_tip'    => __('Enter a brief description that will appear on the customer invoice.', 'lkn-wc-gateway-cielo'),
+                'custom_attributes' => array(
+                    'maxlength' => 50,
+                    'pattern'   => '[a-zA-Z]+( [a-zA-Z]+)*',
+                    'required'  => 'required',
+                    'data-title-description' => __('This description will be used on the transaction invoice. It should be readable and not contain special characters or numbers.', 'lkn-wc-gateway-cielo')
                 )
             ),
             'credit_card' => array(

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -281,6 +281,19 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
                     'data-title-description' => __('Merchant Key credential for API authentication.', 'lkn-wc-gateway-cielo'),
                 )
             ),
+            'env' => array(
+                'title'       => __('Environment', 'lkn-wc-gateway-cielo'),
+                'type'        => 'select',
+                'options'     => array(
+                    'production' => __('Production', 'lkn-wc-gateway-cielo'),
+                    'sandbox'    => __('Development', 'lkn-wc-gateway-cielo'),
+                ),
+                'default'     => 'production',
+                'desc_tip'    => __('Choose between Production or Sandbox environment for the Cielo API.', 'lkn-wc-gateway-cielo'),
+                'custom_attributes' => array(
+                    'data-title-description' => __('Choose between Production or Sandbox environment for the Cielo API.', 'lkn-wc-gateway-cielo'),
+                ),
+            ),
             'establishment_code' => array(
                 'title' => __('Establishment Code', 'lkn-wc-gateway-cielo'),
                 'type' => 'text',
@@ -323,19 +336,6 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
                     'required' => 'required',
                     'data-title-description' => __('Text shown on invoice, must not contain special characters or numbers.', 'lkn-wc-gateway-cielo'),
                 )
-            ),
-            'env' => array(
-                'title'       => __('Environment', 'lkn-wc-gateway-cielo'),
-                'type'        => 'select',
-                'options'     => array(
-                    'production' => __('Production', 'lkn-wc-gateway-cielo'),
-                    'sandbox'    => __('Development', 'lkn-wc-gateway-cielo'),
-                ),
-                'default'     => 'production',
-                'desc_tip'    => __('Choose between Production or Sandbox environment for the Cielo API.', 'lkn-wc-gateway-cielo'),
-                'custom_attributes' => array(
-                    'data-title-description' => __('Choose between Production or Sandbox environment for the Cielo API.', 'lkn-wc-gateway-cielo'),
-                ),
             ),
             'card' => array(
                 'title' => esc_attr__('Card', 'lkn-wc-gateway-cielo'),

--- a/includes/templates/adminSettingsCard.php
+++ b/includes/templates/adminSettingsCard.php
@@ -25,7 +25,7 @@ if (!defined('ABSPATH')) {
             </div>
             <div>
                 <a target="_blank" href=<?php echo esc_url('https://www.linknacional.com.br/wordpress/suporte/'); ?>>
-                    <b>•</b><?php echo esc_attr_e('Suporte WP', 'woo-better-shipping-calculator-for-brazil'); ?>
+                    <b>•</b><?php echo esc_attr_e('Suporte WP', 'lkn-wc-gateway-cielo'); ?>
                 </a>
                 <a target="_blank" href=<?php echo esc_url('https://cliente.linknacional.com.br/solicitar/wordpress-woo-gratis/?utm=plugin'); ?>>
                     <b>•</b><?php echo esc_attr_e('WP Hosting', 'lkn-wc-gateway-cielo'); ?>
@@ -34,7 +34,7 @@ if (!defined('ABSPATH')) {
         </div>
         <div class="LknWcCieloSupportLinks">
             <div id="lknWcCieloStarsDiv">
-                <a target="_blank" href=<?php echo esc_url('https://br.wordpress.org/plugins/woo-better-shipping-calculator-for-brazil/#reviews'); ?>>
+                <a target="_blank" href=<?php echo esc_url('https://br.wordpress.org/plugins/lkn-wc-gateway-cielo/#reviews'); ?>>
                     <p><?php echo esc_attr_e('Rate plugin', 'lkn-wc-gateway-cielo'); ?></p>
                     <div class="LknWcCieloStars">
                         <span class="dashicons dashicons-star-filled lkn-stars"></span>

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -4,7 +4,7 @@
  * Plugin Name: Payment Gateway for Cielo API on WooCommerce
  * Plugin URI: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
  * Description: Adds the Cielo API 3.0 Payments gateway to your WooCommerce website.
- * Version: 1.21.2
+ * Version: 1.21.3
  * Author: Link Nacional
  * Author URI: https://linknacional.com.br
  * Text Domain: lkn-wc-gateway-cielo
@@ -389,7 +389,7 @@ final class LknWCCieloPayment
     {
         // Defines addon version number for easy reference.
         if (! defined('LKN_WC_CIELO_VERSION')) {
-            define('LKN_WC_CIELO_VERSION', '1.21.2');
+            define('LKN_WC_CIELO_VERSION', '1.21.3');
         }
         if (! defined('LKN_WC_CIELO_TRANSLATION_PATH')) {
             define('LKN_WC_CIELO_TRANSLATION_PATH', plugin_dir_path(__FILE__) . 'languages/');

--- a/resources/js/admin/lkn-wc-gateway-admin-layout.js
+++ b/resources/js/admin/lkn-wc-gateway-admin-layout.js
@@ -182,7 +182,7 @@
             label.style.fontSize = '20px'
             label.style.color = '#121519'
 
-            titledesc.style.paddingTop = '68px'
+            titledesc.style.verticalAlign = 'middle'
           }
 
           if (label && helpTip && titledesc) {
@@ -218,7 +218,7 @@
             bodyDiv.style.flexDirection = 'column'
             bodyDiv.style.alignItems = 'start'
             bodyDiv.style.justifyContent = 'center'
-            bodyDiv.style.minHeight = '100px'
+            bodyDiv.style.minHeight = '120px'
             bodyDiv.style.paddingLeft = '4px'
             bodyDiv.style.color = '#2C3338'
 


### PR DESCRIPTION
# Payment Gateway for Cielo API on WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: payment, paymethod, card, credit

Testado até: 6.7.1

Versão estável: 1.21.3

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil)

## Descrição

A Cielo API Payment Gateway for WooCommerce é um plugin de pagamento para WooCommerce que permite integrar sua loja online com a Cielo, uma das principais soluções de pagamento do Brasil. Com este plugin, você pode oferecer aos seus clientes a possibilidade de pagar com cartões de crédito e débito, com suporte a 3DS, garantindo transações seguras e rápidas.

O plugin é fácil de configurar e permite o uso dos principais cartões aceitos pela Cielo, integrando-se de forma nativa com o WooCommerce e simplificando a experiência de checkout em sua loja.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## Resumo(1.21.3):

- Novo layout para o tela de configuração do plugin:
>
![image](https://github.com/user-attachments/assets/87b1e1bc-c058-47ac-b52e-33bb7630caf4)

- Correção no espaçamentos dos títulos principais de cada opção:
>
![image](https://github.com/user-attachments/assets/f9f5b390-64da-4067-a8a4-c942f4a3c890)

- Novo cartão de representação da LinkNacional:
>
![image](https://github.com/user-attachments/assets/4fd40bde-c00a-4054-80c1-e3ee7a74bc86)

- Mudança na posição do campo de `Ambiente` para ficar próximo as credenciais da Cielo. 

- Novo nome para o identificador do método de pagamento pix:
>
![image](https://github.com/user-attachments/assets/0f063528-248d-44b3-be31-790393c98b18)
