### PR TITLE
1.28.0 - wc_cielo_payment_gateway (Siatema de transações da Cielo)

### DIFF
--- a/resources/js/frontend/lkn-cc-dc-installment.js
+++ b/resources/js/frontend/lkn-cc-dc-installment.js
@@ -185,9 +185,9 @@
         // Se a versão PRO está ativa, usar cálculo complexo
         if (typeof lknWCCielo3ds !== 'undefined' && lknWCCielo3ds.licenseResult) {
           // Calcular parcela base: (subtotal + frete) / parcelas + fees externo - descontos + taxes
-          let installmentBase = subtotalShipping / i
+          let installmentBase = (subtotalShipping - discountsTotal) / i
           // Valor final da parcela (fees somados, descontos subtraídos, taxes somados)
-          finalInstallment = installmentBase + feesTotal - discountsTotal + taxesTotal
+          finalInstallment = installmentBase + feesTotal + taxesTotal
 
           // Verificar se tem configuração específica de juros/desconto para esta parcela
           let hasCustomConfig = false
@@ -199,15 +199,15 @@
                 hasCustomConfig = true
               } else if (installmentObj.interest) {
                 // Calcular juros apenas sobre subtotal + frete, depois somar fees, subtrair descontos e somar taxes
-                const interestAmount = subtotalShipping + (subtotalShipping * (installmentObj.interest / 100))
-                const interestInstallment = (interestAmount / i) + feesTotal - discountsTotal + taxesTotal
+                const interestAmount = (subtotalShipping - discountsTotal) + ((subtotalShipping) * (installmentObj.interest / 100))
+                const interestInstallment = (interestAmount / i) + feesTotal + taxesTotal
                 formatedInstallment = new Intl.NumberFormat('pt-br', { style: 'currency', currency: 'BRL' }).format(interestInstallment)
                 text = document.createTextNode(i + 'x de ' + formatedInstallment + ' (' + installmentObj.interest + '% de juros)')
                 hasCustomConfig = true
               } else if (installmentObj.discount) {
                 // Calcular desconto apenas sobre subtotal + frete, depois somar fees, subtrair descontos e somar taxes
-                const discountAmount = subtotalShipping - (subtotalShipping * (installmentObj.discount / 100))
-                const discountInstallment = (discountAmount / i) + feesTotal - discountsTotal + taxesTotal
+                const discountAmount = (subtotalShipping - discountsTotal) - ((subtotalShipping) * (installmentObj.discount / 100))
+                const discountInstallment = (discountAmount / i) + feesTotal + taxesTotal
                 formatedInstallment = new Intl.NumberFormat('pt-br', { style: 'currency', currency: 'BRL' }).format(discountInstallment)
                 text = document.createTextNode(i + 'x de ' + formatedInstallment + ' (' + installmentObj.discount + '% de desconto)')
                 hasCustomConfig = true
@@ -228,8 +228,8 @@
           }
         } else {
           // Versão gratuita: inclui fees externos, descontos e taxes, mas não aplica juros/desconto do plugin
-          // Calcular: (subtotal + frete + fees externos - descontos + taxes) / parcelas
-          finalInstallment = (subtotalShipping + feesTotal - discountsTotal + taxesTotal) / i
+          // Calcular: (subtotal + frete - descontos + fees externos + taxes) / parcelas
+          finalInstallment = (subtotalShipping - discountsTotal + feesTotal + taxesTotal) / i
           formatedInstallment = new Intl.NumberFormat('pt-br', { style: 'currency', currency: 'BRL' }).format(finalInstallment)
           text = document.createTextNode(i + 'x de ' + formatedInstallment)
         }
@@ -248,7 +248,7 @@
 
         // Para versão gratuita, usar o total completo para verificar mínimo
         const checkValue = (typeof lknWCCielo3ds !== 'undefined' && lknWCCielo3ds.licenseResult) ?
-          subtotalShipping : (subtotalShipping + feesTotal - discountsTotal + taxesTotal)
+          subtotalShipping : (subtotalShipping - discountsTotal + feesTotal + taxesTotal)
         if ((checkValue / (i + 1)) < lknInstallmentMin) {
           break
         }

--- a/resources/js/frontend/lkn-cc-installment.js
+++ b/resources/js/frontend/lkn-cc-installment.js
@@ -105,9 +105,9 @@
         // Se a versão PRO está ativa, usar cálculo complexo
         if (typeof lknWCCieloCredit !== 'undefined' && lknWCCieloCredit.licenseResult) {
           // Calcular parcela base: (subtotal + frete) / parcelas + fees externo - descontos + taxes
-          let installmentBase = subtotalShipping / i
+          let installmentBase = (subtotalShipping - discountsTotal) / i
           // Valor final da parcela (fees somados, descontos subtraídos, taxes somados)
-          finalInstallment = installmentBase + feesTotal - discountsTotal + taxesTotal
+          finalInstallment = installmentBase + feesTotal + taxesTotal
 
           // Verificar se tem configuração específica de juros/desconto para esta parcela
           let hasCustomConfig = false
@@ -119,15 +119,15 @@
                 hasCustomConfig = true
               } else if (installmentObj.interest) {
                 // Calcular juros apenas sobre subtotal + frete, depois somar fees, subtrair descontos e somar taxes
-                const interestAmount = subtotalShipping + (subtotalShipping * (installmentObj.interest / 100))
-                const interestInstallment = (interestAmount / i) + feesTotal - discountsTotal + taxesTotal
+                const interestAmount = (subtotalShipping - discountsTotal) + ((subtotalShipping) * (installmentObj.interest / 100))
+                const interestInstallment = (interestAmount / i) + feesTotal + taxesTotal
                 formatedInstallment = new Intl.NumberFormat('pt-br', { style: 'currency', currency: lknWCCieloCredit.currency }).format(interestInstallment)
                 text = document.createTextNode(i + 'x de ' + formatedInstallment + ' (' + installmentObj.interest + '% de juros)')
                 hasCustomConfig = true
               } else if (installmentObj.discount) {
                 // Calcular desconto apenas sobre subtotal + frete, depois somar fees, subtrair descontos e somar taxes
-                const discountAmount = subtotalShipping - (subtotalShipping * (installmentObj.discount / 100))
-                const discountInstallment = (discountAmount / i) + feesTotal - discountsTotal + taxesTotal
+                const discountAmount = (subtotalShipping - discountsTotal) - ((subtotalShipping) * (installmentObj.discount / 100))
+                const discountInstallment = (discountAmount / i) + feesTotal + taxesTotal
                 formatedInstallment = new Intl.NumberFormat('pt-br', { style: 'currency', currency: lknWCCieloCredit.currency }).format(discountInstallment)
                 text = document.createTextNode(i + 'x de ' + formatedInstallment + ' (' + installmentObj.discount + '% de desconto)')
                 hasCustomConfig = true
@@ -148,8 +148,8 @@
           }
         } else {
           // Versão gratuita: inclui fees externos, descontos e taxes, mas não aplica juros/desconto do plugin
-          // Calcular: (subtotal + frete + fees externos - descontos + taxes) / parcelas
-          finalInstallment = (subtotalShipping + feesTotal - discountsTotal + taxesTotal) / i
+          // Calcular: (subtotal + frete - descontos + fees externos + taxes) / parcelas
+          finalInstallment = (subtotalShipping - discountsTotal + feesTotal + taxesTotal) / i
           formatedInstallment = new Intl.NumberFormat('pt-br', { style: 'currency', currency: lknWCCieloCredit.currency }).format(finalInstallment)
           text = document.createTextNode(i + 'x de ' + formatedInstallment)
         }
@@ -168,7 +168,7 @@
 
         // Para versão gratuita, usar o total completo para verificar mínimo
         const checkValue = (typeof lknWCCieloCredit !== 'undefined' && lknWCCieloCredit.licenseResult) ?
-          subtotalShipping : (subtotalShipping + feesTotal - discountsTotal + taxesTotal)
+          subtotalShipping : (subtotalShipping - discountsTotal + feesTotal + taxesTotal)
         if ((checkValue / (i + 1)) < lknInstallmentMin) {
           break
         }


### PR DESCRIPTION
# Cielo Payment Gateway for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, payment, paymethod, card, credit

Testado até: 6.8

Versão estável: 1.28.0

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartão de crédito, débito, Pix e Google Pay através da Cielo diretamente na sua loja WooCommerce.

## Descrição

Integre os gateways de pagamento da Cielo à sua loja WooCommerce e habilite seus clientes a pagarem via cartão de crédito, cartão de débito, Pix e Google Pay.

A [Cielo](https://www.cielo.com.br) é uma das maiores adquirentes do Brasil, oferecendo gateway seguro e eficiente para empresas aceitarem pagamentos online. O plugin oferece suporte completo aos métodos de pagamento da Cielo com autenticação 3DS 2.2 para cartões de débito e recursos avançados de parcelamento com juros/desconto.

**Recursos principais:**

- Cartão de Crédito com parcelamento inteligente
- Cartão de Débito com autenticação 3DS 2.2
- Pagamento via Pix
- Google Pay
- Cálculos de juros/desconto nos parcelamentos
- Compatibilidade com WooCommerce Blocks (Editor de Blocos)
- Layout responsivo e moderno
- Validação de BIN automática
- Suporte a múltiplas moedas

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Cielo Payment Gateway for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Cielo Payment Gateway for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os métodos Cielo desejados.
3. Configure suas credenciais da Cielo (MerchantId, MerchantKey).
4. Configure as opções de parcelamento e juros conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Cielo.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## Novidades (1.28.0):

* Novo sistema de analise das transações realizadas através do plugin da Cielo.

## CHANGELOG:

* Adição do sistema de transações do plugin da Cielo.
* Ajuste no calculo das parcelas com cupom.