### PR TITLE
1.30.4 - wc_cielo_payment_gateway (Ajuste no ID do campo das parcelas)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "1.30.3"
+  DEPLOY_TAG: "1.30.4"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "1.30.3"
+  DEPLOY_TAG: "1.30.4"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.30.4 - 02/04/2026
+* Ajuste no ID do campo das parcelas.
+
 # 1.30.3 - 31/03/2026
 * Ajuste no carregamento do script do Google Pay.
 

--- a/README.txt
+++ b/README.txt
@@ -112,6 +112,10 @@ CIELO API PIX, credit card, debit payment for WooCommerceCIELO API PIX, credit c
 
 == Changelog ==
 
+= 1.30.4 =
+** 02/04/2026 **
+* Fix installments field ID.
+
 = 1.30.3 =
 ** 31/03/2026 **
 * Fixed Google Pay script loading.

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
 Tags: pagamento, cielo, pix, woocommerce, creditcard
 Requires at least: 5.7
 Tested up to: 6.9
-Stable tag: 1.30.3
+Stable tag: 1.30.4
 Requires PHP: 8.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/includes/templates/lkn-cielo-credit-payment-fields-default-layout.php
+++ b/includes/templates/lkn-cielo-credit-payment-fields-default-layout.php
@@ -145,7 +145,7 @@ if (!defined('ABSPATH')) {
                 type="hidden"
                 value="<?php echo esc_attr($discounts_total); ?>">
 
-            <div class="form-row form-row-wide">
+            <div id="lkn-cc-installment-row" class="form-row form-row-wide">
                 <label
                     for="lkn_cc_installments"><?php esc_html_e('Installments', 'lkn-wc-gateway-cielo'); ?>
                     <span class="required">*</span>

--- a/includes/templates/lkn-cielo-credit-payment-fields-default-layout.php
+++ b/includes/templates/lkn-cielo-credit-payment-fields-default-layout.php
@@ -145,7 +145,7 @@ if (!defined('ABSPATH')) {
                 type="hidden"
                 value="<?php echo esc_attr($discounts_total); ?>">
 
-            <div id="lkn-cc-installment-row" class="form-row form-row-wide">
+            <div id="lkn-cc-installment-row" class="form-row form-row-wide" style="display: none;">
                 <label
                     for="lkn_cc_installments"><?php esc_html_e('Installments', 'lkn-wc-gateway-cielo'); ?>
                     <span class="required">*</span>

--- a/includes/templates/lkn-cielo-credit-payment-fields-modern-layout.php
+++ b/includes/templates/lkn-cielo-credit-payment-fields-modern-layout.php
@@ -210,7 +210,7 @@ if (!defined('ABSPATH')) {
                 value="<?php echo esc_attr($discounts_total); ?>">
 
             <!-- Installments Selection -->
-            <div class="modern-field">
+            <div id="lkn-cc-installment-row" class="modern-field" style="display: none;">
                 <label for="lkn_cc_installments" class="field-label">
                     <?php esc_html_e('Installments', 'lkn-wc-gateway-cielo'); ?>
                     <span class="required">*</span>

--- a/includes/templates/lkn-cielo-debit-payment-fields-default-layout.php
+++ b/includes/templates/lkn-cielo-debit-payment-fields-default-layout.php
@@ -397,7 +397,8 @@ if (! defined('ABSPATH')) {
 
         <div
             id="lkn-cc-dc-installment-row"
-            class="form-row form-row-wide">
+            class="form-row form-row-wide"
+            style="display: none;">
             <label
                 for="lkn_cc_dc_installments"><?php esc_html_e('Installments', 'lkn-wc-gateway-cielo'); ?>
                 <span class="required">*</span>

--- a/lkn-wc-gateway-cielo-file.php
+++ b/lkn-wc-gateway-cielo-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('LKN_WC_CIELO_VERSION')) {
-    define('LKN_WC_CIELO_VERSION', '1.30.3');
+    define('LKN_WC_CIELO_VERSION', '1.30.4');
 }
 
 if (! defined('LKN_WC_CIELO_FILE')) {

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -16,7 +16,7 @@
  * Plugin Name:       CIELO API PIX, credit card, debit payment for WooCommerce
  * Plugin URI:        https://www.linknacional.com.br/wordpress/woocommerce/cielo/
  * Description:       Adds the Cielo API 3.0 Payments gateway to your WooCommerce website.
- * Version:           1.30.3
+ * Version:           1.30.4
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br
  * Text Domain:       lkn-wc-gateway-cielo


### PR DESCRIPTION
# Cielo Payment Gateway for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, payment, paymethod, card, credit

Testado até: 6.9

Versão estável: 1.30.4

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartão de crédito, débito, Pix e Google Pay através da Cielo diretamente na sua loja WooCommerce.

## Descrição

Integre os gateways de pagamento da Cielo à sua loja WooCommerce e habilite seus clientes a pagarem via cartão de crédito, cartão de débito, Pix e Google Pay.

A [Cielo](https://www.cielo.com.br) é uma das maiores adquirentes do Brasil, oferecendo gateway seguro e eficiente para empresas aceitarem pagamentos online. O plugin oferece suporte completo aos métodos de pagamento da Cielo com autenticação 3DS 2.2 para cartões de débito e recursos avançados de parcelamento com juros/desconto.

**Recursos principais:**

- Cartão de Crédito com parcelamento inteligente
- Cartão de Débito com autenticação 3DS 2.2
- Pagamento via Pix
- Google Pay
- Cálculos de juros/desconto nos parcelamentos
- Compatibilidade com WooCommerce Blocks (Editor de Blocos)
- Layout responsivo e moderno
- Validação de BIN automática
- Suporte a múltiplas moedas

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Cielo Payment Gateway for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Cielo Payment Gateway for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os métodos Cielo desejados.
3. Configure suas credenciais da Cielo (MerchantId, MerchantKey).
4. Configure as opções de parcelamento e juros conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Cielo.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Ajuste no ID do campo das parcelas.