### PR TITLE
1.32.1 - wc_cielo_payment_gateway (Ajuste no ID do campo das parcelas)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "1.32.0"
+  DEPLOY_TAG: "1.32.1"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "7.4"
-  DEPLOY_TAG: "1.32.0"
+  DEPLOY_TAG: "1.32.1"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.32.1 - 07/05/2026
+* Ajuste na redefinição da parcela do cartão de crédito."
+
 # 1.32.0 - 05/05/2026
 * Adição checkbox para salvar token em 3ds.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 1.32.1 - 07/05/2026
-* Ajuste na redefinição da parcela do cartão de crédito."
+* Ajuste na redefinição da parcela do cartão de crédito.
 
 # 1.32.0 - 05/05/2026
 * Adição checkbox para salvar token em 3ds.

--- a/README.txt
+++ b/README.txt
@@ -111,6 +111,10 @@ CIELO API PIX, credit card, debit payment for WooCommerceCIELO API PIX, credit c
 7. Debit card front page with payment fields.
 
 == Changelog ==
+= 1.32.1 =
+** 07/05/2026 **
+* Adjustment to the credit card installment reset process.
+
 = 1.32.0 =
 ** 05/05/2026 **
 * Add of checkbox to save token in 3DS.

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
 Tags: pagamento, cielo, pix, woocommerce, creditcard
 Requires at least: 5.7
 Tested up to: 6.9
-Stable tag: 1.32.0
+Stable tag: 1.32.1
 Requires PHP: 8.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/includes/LknWCGatewayCieloCredit.php
+++ b/includes/LknWCGatewayCieloCredit.php
@@ -474,10 +474,6 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway
 
         $installmentArgs['currency'] = $currency;
 
-        if (WC()->session) {
-            WC()->session->set('lkn_cielo_credit_installment', '1');
-        }
-
         // Recuperar parcela atual da sessão
         $current_installment = WC()->session ? WC()->session->get('lkn_cielo_credit_installment', '1') : '1';
 

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -739,7 +739,6 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
         $installmentArgs = apply_filters('lkn_wc_cielo_js_3ds_args', array('installment_min' => '5'));
 
         if (WC()->session) {
-            WC()->session->set('lkn_cielo_debit_installment', '1');
             WC()->session->set('lkn_cielo_debit_card_type', 'Credit');
         }
 

--- a/includes/LknWcCieloDebitBlocks.php
+++ b/includes/LknWcCieloDebitBlocks.php
@@ -44,7 +44,6 @@ final class LknWcCieloDebitBlocks extends AbstractPaymentMethodType
         $installmentArgs = apply_filters('lkn_wc_cielo_js_3ds_args', array('installment_min' => '5'));
 
         if (WC()->session) {
-            WC()->session->set('lkn_cielo_debit_installment', '1');
             WC()->session->set('lkn_cielo_debit_card_type', 'Credit');
         }
 

--- a/lkn-wc-gateway-cielo-file.php
+++ b/lkn-wc-gateway-cielo-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('LKN_WC_CIELO_VERSION')) {
-    define('LKN_WC_CIELO_VERSION', '1.32.0');
+    define('LKN_WC_CIELO_VERSION', '1.32.1');
 }
 
 if (! defined('LKN_WC_CIELO_FILE')) {

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -16,7 +16,7 @@
  * Plugin Name:       CIELO API PIX, credit card, debit payment for WooCommerce
  * Plugin URI:        https://www.linknacional.com.br/wordpress/woocommerce/cielo/
  * Description:       Adds the Cielo API 3.0 Payments gateway to your WooCommerce website.
- * Version:           1.32.0
+ * Version:           1.32.1
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br
  * Text Domain:       lkn-wc-gateway-cielo


### PR DESCRIPTION
# Cielo Payment Gateway for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, payment, paymethod, card, credit

Testado até: 6.9

Versão estável: 1.32.1

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartão de crédito, débito, Pix e Google Pay através da Cielo diretamente na sua loja WooCommerce.

## Descrição

Integre os gateways de pagamento da Cielo à sua loja WooCommerce e habilite seus clientes a pagarem via cartão de crédito, cartão de débito, Pix e Google Pay.

A [Cielo](https://www.cielo.com.br) é uma das maiores adquirentes do Brasil, oferecendo gateway seguro e eficiente para empresas aceitarem pagamentos online. O plugin oferece suporte completo aos métodos de pagamento da Cielo com autenticação 3DS 2.2 para cartões de débito e recursos avançados de parcelamento com juros/desconto.

**Recursos principais:**

- Cartão de Crédito com parcelamento inteligente
- Cartão de Débito com autenticação 3DS 2.2
- Pagamento via Pix
- Google Pay
- Cálculos de juros/desconto nos parcelamentos
- Compatibilidade com WooCommerce Blocks (Editor de Blocos)
- Layout responsivo e moderno
- Validação de BIN automática
- Suporte a múltiplas moedas

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Cielo Payment Gateway for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Cielo Payment Gateway for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os métodos Cielo desejados.
3. Configure suas credenciais da Cielo (MerchantId, MerchantKey).
4. Configure as opções de parcelamento e juros conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Cielo.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Ajuste na redefinição da parcela do cartão de crédito.