### PR TITLE
1.33.4 - wc_cielo_payment_gateway (preenchimento dos campos necessários para o 3DS)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
-  PHP_VERSION: "7.4"
+  PHP_VERSION: "8.2"
   DEPLOY_TAG: "1.33.2"
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "8.2"
-  DEPLOY_TAG: "1.33.3"
+  DEPLOY_TAG: "1.33.4"
 
 jobs:
   release-build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "8.2"
-  DEPLOY_TAG: "1.33.2"
+  DEPLOY_TAG: "1.33.3"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "8.2"
-  DEPLOY_TAG: "1.33.3"
+  DEPLOY_TAG: "1.33.4"
 
 jobs:
   deploy-to-wp:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
-  PHP_VERSION: "7.4"
+  PHP_VERSION: "8.2"
   DEPLOY_TAG: "1.33.2"
 
 jobs:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "8.2"
-  DEPLOY_TAG: "1.33.2"
+  DEPLOY_TAG: "1.33.3"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.33.4 - 12/06/2026
+* Ajuste: verificação do nonce.
+
 # 1.33.3 - 11/06/2026
 * Ajuste: preenchimento dos campos necessários para o 3DS.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.33.3 - 11/06/2026
+* Ajuste: preenchimento dos campos necessários para o 3DS.
+
 # 1.33.2 - 01/06/2026
 * Ajuste: Verificação de nonce ao realizar o pedido.
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
 Tags: pagamento, cielo, pix, woocommerce, creditcard
 Requires at least: 5.7
 Tested up to: 6.9
-Stable tag: 1.33.2
+Stable tag: 1.33.3
 Requires PHP: 8.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/README.txt
+++ b/README.txt
@@ -112,6 +112,10 @@ CIELO API PIX, credit card, debit payment for WooCommerceCIELO API PIX, credit c
 7. Debit card front page with payment fields.
 
 == Changelog ==
+= 1.33.3 =
+** 11/06/2026 **
+* Fix: Completion of required fields for 3DS.
+
 = 1.33.2 =
 ** 01/06/2026 **
 * Fix: Nonce verification when placing an order.

--- a/README.txt
+++ b/README.txt
@@ -112,6 +112,10 @@ CIELO API PIX, credit card, debit payment for WooCommerceCIELO API PIX, credit c
 7. Debit card front page with payment fields.
 
 == Changelog ==
+= 1.33.4 =
+** 12/06/2026 **
+* Fix: Nonce verification.
+
 = 1.33.3 =
 ** 11/06/2026 **
 * Fix: Completion of required fields for 3DS.

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
 Tags: pagamento, cielo, pix, woocommerce, creditcard
 Requires at least: 5.7
 Tested up to: 6.9
-Stable tag: 1.33.3
+Stable tag: 1.33.4
 Requires PHP: 8.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/includes/LknWCCieloPayment.php
+++ b/includes/LknWCCieloPayment.php
@@ -733,8 +733,8 @@ final class LknWCCieloPayment
     {
         // Verificar se usuario já dispensou a notificação
         $notice_dismissed = get_option('lkn_fraud_notice_dismissed', 'no');
-        
-        if ($notice_dismissed === 'no' && !file_exists(WP_PLUGIN_DIR . '/fraud-detection-for-woocommerce/fraud-detection-for-woocommerce.php') && (!is_plugin_active('integration-rede-for-woocommerce/integration-rede-for-woocommerce.php') && !is_plugin_active('woo-rede/integration-rede-for-woocommerce.php'))) {
+
+        if ($notice_dismissed === 'yes' && (!file_exists(WP_PLUGIN_DIR . '/fraud-scam-detection-woocommerce/fraud-scam-detection-woocommerce.php') && !file_exists(WP_PLUGIN_DIR . '/fraud-and-scam-detection-for-woocommerce/fraud-scam-detection-woocommerce.php')) && (!is_plugin_active('integration-rede-for-woocommerce/integration-rede-for-woocommerce.php') && !is_plugin_active('woo-rede/integration-rede-for-woocommerce.php'))) {
             // Enfileirar script para dismiss da notificação
             wp_enqueue_script('lkn-cielo-dismiss-notice', LKN_WC_GATEWAY_CIELO_DIR_URL . 'resources/js/admin/lkn-dismiss-fraud-notice.js', array('jquery'), LKN_WC_CIELO_VERSION, true);
             wp_localize_script('lkn-cielo-dismiss-notice', 'lknCieloDismissNotice', array(
@@ -1317,7 +1317,8 @@ final class LknWCCieloPayment
         }
 
         // Atualizar opção para dispensar a notificação
-        $updated = update_option('lkn_cielo_fraud_notice_dismissed', 'yes');
+        update_option('lkn_cielo_fraud_notice_dismissed', 'yes');
+        $updated = get_option('lkn_cielo_fraud_notice_dismissed') === 'yes';
 
         if ($updated) {
             wp_send_json_success(array('message' => __('Notice dismissed successfully', 'lkn-wc-gateway-cielo')));

--- a/includes/LknWCCieloPayment.php
+++ b/includes/LknWCCieloPayment.php
@@ -734,7 +734,7 @@ final class LknWCCieloPayment
         // Verificar se usuario já dispensou a notificação
         $notice_dismissed = get_option('lkn_fraud_notice_dismissed', 'no');
 
-        if ($notice_dismissed === 'yes' && (!file_exists(WP_PLUGIN_DIR . '/fraud-scam-detection-woocommerce/fraud-scam-detection-woocommerce.php') && !file_exists(WP_PLUGIN_DIR . '/fraud-and-scam-detection-for-woocommerce/fraud-scam-detection-woocommerce.php')) && (!is_plugin_active('integration-rede-for-woocommerce/integration-rede-for-woocommerce.php') && !is_plugin_active('woo-rede/integration-rede-for-woocommerce.php'))) {
+        if ($notice_dismissed === 'no' && (!file_exists(WP_PLUGIN_DIR . '/fraud-scam-detection-woocommerce/fraud-scam-detection-woocommerce.php') && !file_exists(WP_PLUGIN_DIR . '/fraud-and-scam-detection-for-woocommerce/fraud-scam-detection-woocommerce.php')) && (!is_plugin_active('integration-rede-for-woocommerce/integration-rede-for-woocommerce.php') && !is_plugin_active('woo-rede/integration-rede-for-woocommerce.php'))) {
             // Enfileirar script para dismiss da notificação
             wp_enqueue_script('lkn-cielo-dismiss-notice', LKN_WC_GATEWAY_CIELO_DIR_URL . 'resources/js/admin/lkn-dismiss-fraud-notice.js', array('jquery'), LKN_WC_CIELO_VERSION, true);
             wp_localize_script('lkn-cielo-dismiss-notice', 'lknCieloDismissNotice', array(

--- a/includes/LknWCGatewayCieloCredit.php
+++ b/includes/LknWCGatewayCieloCredit.php
@@ -619,10 +619,11 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway
      */
     public function validate_fields()
     {
+        $nonceInactive = $this->get_option('nonce_compatibility', 'no');
         $validateCompatMode = $this->get_option('input_validation_compatibility', 'no');
         $nonce = isset($_POST['nonce_lkn_cielo_credit']) ? sanitize_text_field(wp_unslash($_POST['nonce_lkn_cielo_credit'])) : '';
 
-        if (! wp_verify_nonce($nonce, 'nonce_lkn_cielo_credit') && 'no' === $validateCompatMode) {
+        if (! wp_verify_nonce($nonce, 'nonce_lkn_cielo_credit') && 'no' === $nonceInactive) {
             $this->log->log('error', 'Nonce verification failed. Nonce: ' . var_export($nonce, true), array('source' => 'woocommerce-cielo-credit'));
             $this->add_notice_once(__('Nonce verification failed, try reloading the page', 'lkn-wc-gateway-cielo'), 'error');
             return false;

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -929,13 +929,38 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
 
         $name = $user->display_name;
         $email = $user->user_email;
+        // Fallback: billing → shipping → custom → vazio, para garantir dados ELO obrigatórios
         $billing_phone = get_user_meta($user->ID, 'billing_phone', true);
+        if (empty($billing_phone)) {
+            $billing_phone = get_user_meta($user->ID, 'shipping_phone', true);
+        }
+        if (empty($billing_phone)) {
+            $billing_phone = get_user_meta($user->ID, 'phone', true);
+        }
         $billing_address_1 = get_user_meta($user->ID, 'billing_address_1', true);
+        if (empty($billing_address_1)) {
+            $billing_address_1 = get_user_meta($user->ID, 'shipping_address_1', true);
+        }
         $billing_address_2 = get_user_meta($user->ID, 'billing_address_2', true);
+        if (empty($billing_address_2)) {
+            $billing_address_2 = get_user_meta($user->ID, 'shipping_address_2', true);
+        }
         $billing_city = get_user_meta($user->ID, 'billing_city', true);
+        if (empty($billing_city)) {
+            $billing_city = get_user_meta($user->ID, 'shipping_city', true);
+        }
         $billing_state = get_user_meta($user->ID, 'billing_state', true);
+        if (empty($billing_state)) {
+            $billing_state = get_user_meta($user->ID, 'shipping_state', true);
+        }
         $billing_postcode = get_user_meta($user->ID, 'billing_postcode', true);
+        if (empty($billing_postcode)) {
+            $billing_postcode = get_user_meta($user->ID, 'shipping_postcode', true);
+        }
         $billing_country = get_user_meta($user->ID, 'billing_country', true);
+        if (empty($billing_country)) {
+            $billing_country = get_user_meta($user->ID, 'shipping_country', true);
+        }
         $billing_document = $billingDocument;
 
         ?>

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -1022,11 +1022,12 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
      */
     public function validate_fields()
     {
+        $nonceInactive = $this->get_option('nonce_compatibility', 'no');
         $validateCompatMode = $this->get_option('input_validation_compatibility', 'no');
         $nonce = isset($_POST['nonce_lkn_cielo_debit']) ? sanitize_text_field(wp_unslash($_POST['nonce_lkn_cielo_debit'])) : '';
         $saveCardIndex = isset($_POST['lkn_selected_saved_card_index']) ? sanitize_text_field(wp_unslash($_POST['lkn_selected_saved_card_index'])) : '';
 
-        if (! wp_verify_nonce($nonce, 'nonce_lkn_cielo_debit')) {
+        if (! wp_verify_nonce($nonce, 'nonce_lkn_cielo_debit') && 'no' === $nonceInactive) {
             $this->log->log('error', 'Nonce verification failed. Nonce: ' . var_export($nonce, true), array('source' => 'woocommerce-cielo-debit'));
             $this->add_notice_once(__('Nonce verification failed, try reloading the page', 'lkn-wc-gateway-cielo'), 'error');
             return false;

--- a/includes/LknWcCieloDebitBlocks.php
+++ b/includes/LknWcCieloDebitBlocks.php
@@ -282,13 +282,14 @@ final class LknWcCieloDebitBlocks extends AbstractPaymentMethodType
             'client' => array(
                 'name' => $user->display_name,
                 'email' => $user->user_email,
-                'billing_phone' => get_user_meta($user->ID, 'billing_phone', true),
-                'billing_address_1' => get_user_meta($user->ID, 'billing_address_1', true),
-                'billing_address_2' => get_user_meta($user->ID, 'billing_address_2', true),
-                'billing_city' => get_user_meta($user->ID, 'billing_city', true),
-                'billing_state' => get_user_meta($user->ID, 'billing_state', true),
-                'billing_postcode' => get_user_meta($user->ID, 'billing_postcode', true),
-                'billing_country' => get_user_meta($user->ID, 'billing_country', true),
+                // Fallback: billing → shipping → custom → vazio, para garantir dados ELO obrigatórios
+                'billing_phone' => $this->get_user_meta_fallback($user->ID, 'billing_phone', 'shipping_phone', 'custom-phone'),
+                'billing_address_1' => $this->get_user_meta_fallback($user->ID, 'billing_address_1', 'shipping_address_1'),
+                'billing_address_2' => $this->get_user_meta_fallback($user->ID, 'billing_address_2', 'shipping_address_2'),
+                'billing_city' => $this->get_user_meta_fallback($user->ID, 'billing_city', 'shipping_city'),
+                'billing_state' => $this->get_user_meta_fallback($user->ID, 'billing_state', 'shipping_state'),
+                'billing_postcode' => $this->get_user_meta_fallback($user->ID, 'billing_postcode', 'shipping_postcode'),
+                'billing_country' => $this->get_user_meta_fallback($user->ID, 'billing_country', 'shipping_country'),
                 'billing_document' => $billingDocument
             ),
             'translations' => array(
@@ -311,5 +312,27 @@ final class LknWcCieloDebitBlocks extends AbstractPaymentMethodType
                 'calculatingInstallments' => __('Calculating installments...', 'lkn-wc-gateway-cielo'),
             )
         );
+    }
+
+    /**
+     * Helper method: retorna o valor do primeiro meta key que existir e não for vazio.
+     * Suporta fallback em múltiplas chaves (ex: billing_phone → shipping_phone → phone).
+     *
+     * @param int   $user_id
+     * @param string ...$keys  Lista ordenada de meta keys para tentar
+     * @return string
+     */
+    private function get_user_meta_fallback($user_id, ...$keys)
+    {
+        foreach ($keys as $key) {
+            if (empty($key)) {
+                continue;
+            }
+            $value = get_user_meta($user_id, $key, true);
+            if (! empty($value) && false !== $value) {
+                return $value;
+            }
+        }
+        return '';
     }
 }

--- a/includes/templates/lkn-cielo-debit-payment-fields-default-layout.php
+++ b/includes/templates/lkn-cielo-debit-payment-fields-default-layout.php
@@ -249,6 +249,37 @@ if (! defined('ABSPATH')) {
         name="lkn_card_brand_establishment_code"
         className="bpmpi_brand_establishment_code"
         value="<?php echo esc_attr($bec); ?>" />
+    <!-- Browser info fields for 3DS ELO compliance -->
+    <input
+        type="hidden"
+        id="lkn_bpmpi_device_useragent"
+        name="lkn_card_device_useragent"
+        className="bpmpi_device_useragent" />
+    <input
+        type="hidden"
+        id="lkn_bpmpi_device_screenwidth"
+        name="lkn_card_device_screenwidth"
+        className="bpmpi_device_screenwidth" />
+    <input
+        type="hidden"
+        id="lkn_bpmpi_device_screenheight"
+        name="lkn_card_device_screenheight"
+        className="bpmpi_device_screenheight" />
+    <input
+        type="hidden"
+        id="lkn_bpmpi_device_colordepth"
+        name="lkn_card_device_colordepth"
+        className="bpmpi_device_colordepth" />
+    <input
+        type="hidden"
+        id="lkn_bpmpi_device_timezone"
+        name="lkn_card_device_timezone"
+        className="bpmpi_device_timezone" />
+    <input
+        type="hidden"
+        id="lkn_bpmpi_device_javaenabled"
+        name="lkn_card_device_javaenabled"
+        className="bpmpi_device_javaenabled" />
     <input
         type="hidden"
         id="lkn_cavv"

--- a/includes/templates/lkn-cielo-debit-payment-fields-modern-layout.php
+++ b/includes/templates/lkn-cielo-debit-payment-fields-modern-layout.php
@@ -134,6 +134,13 @@ if (!defined('ABSPATH')) {
         <input type="hidden" size="45" id="lkn_bpmpi_device_ipaddress" name="lkn_card_device_ipaddress" className="bpmpi_device_ipaddress" value="<?php echo esc_attr($client_ip); ?>" />
         <input type="hidden" size="7" id="lkn_bpmpi_device_channel" name="lkn_card_device_channel" className="bpmpi_device_channel" value="Browser" />
         <input type="hidden" size="10" id="lkn_bpmpi_brand_establishment_code" name="lkn_card_brand_establishment_code" className="bpmpi_brand_establishment_code" value="<?php echo esc_attr($bec); ?>" />
+        <!-- Browser info fields for 3DS ELO compliance -->
+        <input type="hidden" id="lkn_bpmpi_device_useragent" name="lkn_card_device_useragent" className="bpmpi_device_useragent" />
+        <input type="hidden" id="lkn_bpmpi_device_screenwidth" name="lkn_card_device_screenwidth" className="bpmpi_device_screenwidth" />
+        <input type="hidden" id="lkn_bpmpi_device_screenheight" name="lkn_card_device_screenheight" className="bpmpi_device_screenheight" />
+        <input type="hidden" id="lkn_bpmpi_device_colordepth" name="lkn_card_device_colordepth" className="bpmpi_device_colordepth" />
+        <input type="hidden" id="lkn_bpmpi_device_timezone" name="lkn_card_device_timezone" className="bpmpi_device_timezone" />
+        <input type="hidden" id="lkn_bpmpi_device_javaenabled" name="lkn_card_device_javaenabled" className="bpmpi_device_javaenabled" />
         <input type="hidden" id="lkn_cavv" name="lkn_cielo_3ds_cavv" value="true" />
         <input type="hidden" id="lkn_eci" name="lkn_cielo_3ds_eci" value="true" />
         <input type="hidden" id="lkn_ref_id" name="lkn_cielo_3ds_ref_id" value="true" />

--- a/lkn-wc-gateway-cielo-file.php
+++ b/lkn-wc-gateway-cielo-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('LKN_WC_CIELO_VERSION')) {
-    define('LKN_WC_CIELO_VERSION', '1.33.3');
+    define('LKN_WC_CIELO_VERSION', '1.33.4');
 }
 
 if (! defined('LKN_WC_CIELO_FILE')) {

--- a/lkn-wc-gateway-cielo-file.php
+++ b/lkn-wc-gateway-cielo-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('LKN_WC_CIELO_VERSION')) {
-    define('LKN_WC_CIELO_VERSION', '1.33.2');
+    define('LKN_WC_CIELO_VERSION', '1.33.3');
 }
 
 if (! defined('LKN_WC_CIELO_FILE')) {

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -16,7 +16,7 @@
  * Plugin Name:       CIELO API PIX, credit card, debit payment for WooCommerce
  * Plugin URI:        https://www.linknacional.com.br/wordpress/woocommerce/cielo/
  * Description:       Adds the Cielo API 3.0 Payments gateway to your WooCommerce website.
- * Version:           1.33.3
+ * Version:           1.33.4
  * Requires PHP:      8.2
  * Requires at least: 5.8
  * Author:            Link Nacional

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -16,7 +16,7 @@
  * Plugin Name:       CIELO API PIX, credit card, debit payment for WooCommerce
  * Plugin URI:        https://www.linknacional.com.br/wordpress/woocommerce/cielo/
  * Description:       Adds the Cielo API 3.0 Payments gateway to your WooCommerce website.
- * Version:           1.33.2
+ * Version:           1.33.3
  * Requires PHP:      8.2
  * Requires at least: 5.8
  * Author:            Link Nacional

--- a/resources/js/debitCard/lkn-dc-script-prd.js
+++ b/resources/js/debitCard/lkn-dc-script-prd.js
@@ -96,50 +96,68 @@ function lknDCProccessButton () {
   lknProcessDebitCard()
 }
 
+// Helper: retorna o primeiro valor não vazio de uma lista de IDs (fallback billing → shipping → custom)
+function getDomValueWithFallback (ids) {
+  for (var i = 0; i < ids.length; i++) {
+    var el = document.getElementById(ids[i])
+    if (el && el.value && el.value.trim() !== '') {
+      return el.value.trim()
+    }
+  }
+  return ''
+}
+
+// Helper: seta valor em elemento se existir
+function setIfExists (id, value) {
+  var el = document.getElementById(id)
+  if (el) el.value = value
+}
+
 // Função para processar cartão de débito (com 3DS)
 function lknProcessDebitCard () {
   try {
-    const cardNumber = document.getElementById('lkn_dcno').value.replace(/\D/g, '')
-    const cardHolder = document.getElementById('lkn_dc_cardholder_name')
+    var cardNumber = document.getElementById('lkn_dcno').value.replace(/\D/g, '')
+    var cardHolder = document.getElementById('lkn_dc_cardholder_name')
 
-    if (cardHolder) {
-      document.getElementById('lkn_bpmpi_billto_contactname').value = cardHolder.value
+    // Nome do portador: cardholder > billing_first_name + billing_last_name > DOM block
+    if (cardHolder && cardHolder.value.trim() !== '') {
+      setIfExists('lkn_bpmpi_billto_contactname', cardHolder.value)
     } else {
-      const firstNameElement = document.getElementById('billing_first_name')
-      const lastNameElement = document.getElementById('billing_last_name')
-
-      if(firstNameElement && lastNameElement) {
-        firstName = firstNameElement.value
-        lastName = lastNameElement.value
-        document.getElementById('lkn_bpmpi_billto_contactname').value = firstName + ' ' + lastName
-      }else{
-        nameElement = document.querySelector('.wc-block-components-address-card__address-section')
-        document.getElementById('lkn_bpmpi_billto_contactname').value = nameElement.valeu
+      var firstName = getDomValueWithFallback(['billing_first_name', 'shipping_first_name'])
+      var lastName = getDomValueWithFallback(['billing_last_name', 'shipping_last_name'])
+      if (firstName || lastName) {
+        setIfExists('lkn_bpmpi_billto_contactname', (firstName + ' ' + lastName).trim())
+      } else {
+        var nameBlock = document.querySelector('.wc-block-components-address-card__address-section')
+        if (nameBlock && nameBlock.textContent) {
+          setIfExists('lkn_bpmpi_billto_contactname', nameBlock.textContent.trim())
+        }
       }
     }
 
-    const phoneNumber = document.getElementById('billing-phone') ? document.getElementById('billing-phone').value : ''
-    const billingCountry = document.getElementById('billing-country') ? document.getElementById('billing-country').value : ''
-    const billingAddress1 = document.getElementById('billing-address_1') ? document.getElementById('billing-address_1').value : ''
-    const billingAddress2 = document.getElementById('billing-address_2') ? document.getElementById('billing-address_2').value : ''
-    const billingCity = document.getElementById('billing-city') ? document.getElementById('billing-city').value : ''
-    const billingPostcode = document.getElementById('billing-postcode') ? document.getElementById('billing-postcode').value : ''
-    const billingState = document.getElementById('billing-state') ? document.getElementById('billing-state').value : ''
-    const email = document.getElementById('email') ? document.getElementById('email').value : ''
-    
-    // Busca CPF/CNPJ em ordem de prioridade: campo personalizado > billing_cpf > billing_cnpj
-    const billingDocument = (function() {
-      const customField = document.getElementById('lknCieloApiPixBillingCpf')
-      const billingCpf = document.getElementById('billing_cpf')  
-      const billingCnpj = document.getElementById('billing_cnpj')
-      
-      if (customField && customField.value) return customField.value
-      if (billingCpf && billingCpf.value) return billingCpf.value
-      if (billingCnpj && billingCnpj.value) return billingCnpj.value
-      return ''
-    })()
+    // Dados do portador com fallback billing → shipping → custom
+    // Phone: billing-phone → shipping-phone → custom-phone
+    setIfExists('lkn_bpmpi_billto_phonenumber', getDomValueWithFallback(['billing-phone', 'shipping-phone', 'custom-phone']))
+    setIfExists('lkn_bpmpi_billto_street1', getDomValueWithFallback(['billing-address_1', 'shipping-address_1']))
+    setIfExists('lkn_bpmpi_billto_street2', getDomValueWithFallback(['billing-address_2', 'shipping-address_2']))
+    setIfExists('lkn_bpmpi_billto_city', getDomValueWithFallback(['billing-city', 'shipping-city']))
+    setIfExists('lkn_bpmpi_billto_state', getDomValueWithFallback(['billing-state', 'shipping-state']))
+    setIfExists('lkn_bpmpi_billto_zipcode', getDomValueWithFallback(['billing-postcode', 'shipping-postcode']))
+    setIfExists('lkn_bpmpi_billto_country', getDomValueWithFallback(['billing-country', 'shipping-country']))
+    setIfExists('lkn_bpmpi_billto_email', getDomValueWithFallback(['billing-email', 'shipping-email', 'email']))
 
-    let expDate = document.getElementById('lkn_dc_expdate').value
+    // CPF/CNPJ: campo personalizado > billing_cpf > billing_cnpj
+    setIfExists('lkn_bpmpi_billto_customerid', getDomValueWithFallback(['lknCieloApiPixBillingCpf', 'billing_cpf', 'billing_cnpj']))
+
+    // Browser info para conformidade ELO 3DS
+    setIfExists('lkn_bpmpi_device_useragent', navigator.userAgent || '')
+    setIfExists('lkn_bpmpi_device_screenwidth', (screen.width || window.innerWidth || 0).toString())
+    setIfExists('lkn_bpmpi_device_screenheight', (screen.height || window.innerHeight || 0).toString())
+    setIfExists('lkn_bpmpi_device_colordepth', (screen.colorDepth || 24).toString())
+    setIfExists('lkn_bpmpi_device_timezone', (new Date().getTimezoneOffset()).toString())
+    setIfExists('lkn_bpmpi_device_javaenabled', (typeof navigator.javaEnabled === 'function' && navigator.javaEnabled()) ? 'true' : 'false')
+
+    var expDate = document.getElementById('lkn_dc_expdate').value
 
     expDate = expDate.split('/')
 
@@ -147,21 +165,9 @@ function lknProcessDebitCard () {
       expDate[1] = '20' + expDate[1]
     }
 
-    document.getElementById('lkn_bpmpi_cardnumber').value = cardNumber
-    document.getElementById('lkn_bpmpi_expmonth').value = expDate[0].replace(/\D/g, '')
-    document.getElementById('lkn_bpmpi_expyear').value = expDate[1].replace(/\D/g, '')
-
-    if (document.getElementById('lkn_bpmpi_useraccount_guest').value === 'true') {
-      document.getElementById('lkn_bpmpi_billto_customerid').value = billingDocument
-      document.getElementById('lkn_bpmpi_billto_phonenumber').value = phoneNumber
-      document.getElementById('lkn_bpmpi_billto_email').value = email
-      document.getElementById('lkn_bpmpi_billto_street1').value = billingAddress1
-      document.getElementById('lkn_bpmpi_billto_street2').value = billingAddress2
-      document.getElementById('lkn_bpmpi_billto_city').value = billingCity
-      document.getElementById('lkn_bpmpi_billto_state').value = billingState
-      document.getElementById('lkn_bpmpi_billto_zipcode').value = billingPostcode
-      document.getElementById('lkn_bpmpi_billto_country').value = billingCountry
-    }
+    setIfExists('lkn_bpmpi_cardnumber', cardNumber)
+    setIfExists('lkn_bpmpi_expmonth', expDate[0].replace(/\D/g, ''))
+    setIfExists('lkn_bpmpi_expyear', expDate[1].replace(/\D/g, ''))
 
     bpmpi_authenticate()
   } catch (error) {

--- a/resources/js/debitCard/lkn-dc-script-sdb.js
+++ b/resources/js/debitCard/lkn-dc-script-sdb.js
@@ -97,50 +97,68 @@ function lknDCProccessButton () {
   lknProcessDebitCard()
 }
 
+// Helper: retorna o primeiro valor não vazio de uma lista de IDs (fallback billing → shipping → custom)
+function getDomValueWithFallback (ids) {
+  for (var i = 0; i < ids.length; i++) {
+    var el = document.getElementById(ids[i])
+    if (el && el.value && el.value.trim() !== '') {
+      return el.value.trim()
+    }
+  }
+  return ''
+}
+
+// Helper: seta valor em elemento se existir
+function setIfExists (id, value) {
+  var el = document.getElementById(id)
+  if (el) el.value = value
+}
+
 // Função para processar cartão de débito (com 3DS)
 function lknProcessDebitCard () {
   try {
-    const cardNumber = document.getElementById('lkn_dcno').value.replace(/\D/g, '')
-    const cardHolder = document.getElementById('lkn_dc_cardholder_name')
+    var cardNumber = document.getElementById('lkn_dcno').value.replace(/\D/g, '')
+    var cardHolder = document.getElementById('lkn_dc_cardholder_name')
 
-    if (cardHolder) {
-      document.getElementById('lkn_bpmpi_billto_contactname').value = cardHolder.value
+    // Nome do portador: cardholder > billing_first_name + billing_last_name > DOM block
+    if (cardHolder && cardHolder.value.trim() !== '') {
+      setIfExists('lkn_bpmpi_billto_contactname', cardHolder.value)
     } else {
-      const firstNameElement = document.getElementById('billing_first_name')
-      const lastNameElement = document.getElementById('billing_last_name')
-
-      if(firstNameElement && lastNameElement) {
-        firstName = firstNameElement.value
-        lastName = lastNameElement.value
-        document.getElementById('lkn_bpmpi_billto_contactname').value = firstName + ' ' + lastName
-      }else{
-        nameElement = document.querySelector('.wc-block-components-address-card__address-section')
-        document.getElementById('lkn_bpmpi_billto_contactname').value = nameElement.valeu
+      var firstName = getDomValueWithFallback(['billing_first_name', 'shipping_first_name'])
+      var lastName = getDomValueWithFallback(['billing_last_name', 'shipping_last_name'])
+      if (firstName || lastName) {
+        setIfExists('lkn_bpmpi_billto_contactname', (firstName + ' ' + lastName).trim())
+      } else {
+        var nameBlock = document.querySelector('.wc-block-components-address-card__address-section')
+        if (nameBlock && nameBlock.textContent) {
+          setIfExists('lkn_bpmpi_billto_contactname', nameBlock.textContent.trim())
+        }
       }
     }
 
-    const phoneNumber = document.getElementById('billing-phone') ? document.getElementById('billing-phone').value : ''
-    const billingCountry = document.getElementById('billing-country') ? document.getElementById('billing-country').value : ''
-    const billingAddress1 = document.getElementById('billing-address_1') ? document.getElementById('billing-address_1').value : ''
-    const billingAddress2 = document.getElementById('billing-address_2') ? document.getElementById('billing-address_2').value : ''
-    const billingCity = document.getElementById('billing-city') ? document.getElementById('billing-city').value : ''
-    const billingPostcode = document.getElementById('billing-postcode') ? document.getElementById('billing-postcode').value : ''
-    const billingState = document.getElementById('billing-state') ? document.getElementById('billing-state').value : ''
-    const email = document.getElementById('email') ? document.getElementById('email').value : ''
-    
-    // Busca CPF/CNPJ em ordem de prioridade: campo personalizado > billing_cpf > billing_cnpj
-    const billingDocument = (function() {
-      const customField = document.getElementById('lknCieloApiPixBillingCpf')
-      const billingCpf = document.getElementById('billing_cpf')  
-      const billingCnpj = document.getElementById('billing_cnpj')
-      
-      if (customField && customField.value) return customField.value
-      if (billingCpf && billingCpf.value) return billingCpf.value
-      if (billingCnpj && billingCnpj.value) return billingCnpj.value
-      return ''
-    })()
+    // Dados do portador com fallback billing → shipping → custom
+    // Phone: billing-phone → shipping-phone → custom-phone
+    setIfExists('lkn_bpmpi_billto_phonenumber', getDomValueWithFallback(['billing-phone', 'shipping-phone', 'custom-phone']))
+    setIfExists('lkn_bpmpi_billto_street1', getDomValueWithFallback(['billing-address_1', 'shipping-address_1']))
+    setIfExists('lkn_bpmpi_billto_street2', getDomValueWithFallback(['billing-address_2', 'shipping-address_2']))
+    setIfExists('lkn_bpmpi_billto_city', getDomValueWithFallback(['billing-city', 'shipping-city']))
+    setIfExists('lkn_bpmpi_billto_state', getDomValueWithFallback(['billing-state', 'shipping-state']))
+    setIfExists('lkn_bpmpi_billto_zipcode', getDomValueWithFallback(['billing-postcode', 'shipping-postcode']))
+    setIfExists('lkn_bpmpi_billto_country', getDomValueWithFallback(['billing-country', 'shipping-country']))
+    setIfExists('lkn_bpmpi_billto_email', getDomValueWithFallback(['billing-email', 'shipping-email', 'email']))
 
-    let expDate = document.getElementById('lkn_dc_expdate').value
+    // CPF/CNPJ: campo personalizado > billing_cpf > billing_cnpj
+    setIfExists('lkn_bpmpi_billto_customerid', getDomValueWithFallback(['lknCieloApiPixBillingCpf', 'billing_cpf', 'billing_cnpj']))
+
+    // Browser info para conformidade ELO 3DS
+    setIfExists('lkn_bpmpi_device_useragent', navigator.userAgent || '')
+    setIfExists('lkn_bpmpi_device_screenwidth', (screen.width || window.innerWidth || 0).toString())
+    setIfExists('lkn_bpmpi_device_screenheight', (screen.height || window.innerHeight || 0).toString())
+    setIfExists('lkn_bpmpi_device_colordepth', (screen.colorDepth || 24).toString())
+    setIfExists('lkn_bpmpi_device_timezone', (new Date().getTimezoneOffset()).toString())
+    setIfExists('lkn_bpmpi_device_javaenabled', (typeof navigator.javaEnabled === 'function' && navigator.javaEnabled()) ? 'true' : 'false')
+
+    var expDate = document.getElementById('lkn_dc_expdate').value
 
     expDate = expDate.split('/')
 
@@ -148,21 +166,9 @@ function lknProcessDebitCard () {
       expDate[1] = '20' + expDate[1]
     }
 
-    document.getElementById('lkn_bpmpi_cardnumber').value = cardNumber
-    document.getElementById('lkn_bpmpi_expmonth').value = expDate[0].replace(/\D/g, '')
-    document.getElementById('lkn_bpmpi_expyear').value = expDate[1].replace(/\D/g, '')
-
-    if (document.getElementById('lkn_bpmpi_useraccount_guest').value === 'true') {
-      document.getElementById('lkn_bpmpi_billto_customerid').value = billingDocument
-      document.getElementById('lkn_bpmpi_billto_phonenumber').value = phoneNumber
-      document.getElementById('lkn_bpmpi_billto_email').value = email
-      document.getElementById('lkn_bpmpi_billto_street1').value = billingAddress1
-      document.getElementById('lkn_bpmpi_billto_street2').value = billingAddress2
-      document.getElementById('lkn_bpmpi_billto_city').value = billingCity
-      document.getElementById('lkn_bpmpi_billto_state').value = billingState
-      document.getElementById('lkn_bpmpi_billto_zipcode').value = billingPostcode
-      document.getElementById('lkn_bpmpi_billto_country').value = billingCountry
-    }
+    setIfExists('lkn_bpmpi_cardnumber', cardNumber)
+    setIfExists('lkn_bpmpi_expmonth', expDate[0].replace(/\D/g, ''))
+    setIfExists('lkn_bpmpi_expyear', expDate[1].replace(/\D/g, ''))
 
     bpmpi_authenticate()
   } catch (error) {

--- a/resources/js/debitCard/lknCieloDebit.tsx
+++ b/resources/js/debitCard/lknCieloDebit.tsx
@@ -556,6 +556,13 @@ const lknDCContentCielo = (props) => {
         <input type="hidden" id="lkn_bpmpi_useraccount_authenticationmethod" name="lkn_card_useraccount_authenticationmethod" className="bpmpi_useraccount_authenticationmethod" value={lknDCAuthMethod} />
         <input type="hidden" size="45" id="lkn_bpmpi_device_ipaddress" name="lkn_card_device_ipaddress" className="bpmpi_device_ipaddress" value={lknDCClientIp} />
         <input type="hidden" size="7" id="lkn_bpmpi_device_channel" name="lkn_card_device_channel" className="bpmpi_device_channel" value="Browser" />
+        {/* Browser info fields for 3DS ELO compliance - populated by JS before bpmpi_authenticate() */}
+        <input type="hidden" id="lkn_bpmpi_device_useragent" name="lkn_card_device_useragent" className="bpmpi_device_useragent" />
+        <input type="hidden" id="lkn_bpmpi_device_screenwidth" name="lkn_card_device_screenwidth" className="bpmpi_device_screenwidth" />
+        <input type="hidden" id="lkn_bpmpi_device_screenheight" name="lkn_card_device_screenheight" className="bpmpi_device_screenheight" />
+        <input type="hidden" id="lkn_bpmpi_device_colordepth" name="lkn_card_device_colordepth" className="bpmpi_device_colordepth" />
+        <input type="hidden" id="lkn_bpmpi_device_timezone" name="lkn_card_device_timezone" className="bpmpi_device_timezone" />
+        <input type="hidden" id="lkn_bpmpi_device_javaenabled" name="lkn_card_device_javaenabled" className="bpmpi_device_javaenabled" />
         <input type="hidden" size="10" id="lkn_bpmpi_brand_establishment_code" name="lkn_card_brand_establishment_code" className="bpmpi_brand_establishment_code" value={lknDCBec} />
         <input type="hidden" id="lkn_cavv" name="lkn_cielo_3ds_cavv" value />
         <input type="hidden" id="lkn_eci" name="lkn_cielo_3ds_eci" value />

--- a/resources/js/frontend/lkn-dc-script-prd.js
+++ b/resources/js/frontend/lkn-dc-script-prd.js
@@ -340,6 +340,58 @@ function lknDCProccessButton () {
     document.getElementById('lkn_bpmpi_expmonth').value = expDate[0].replace(/\D/g, '')
     document.getElementById('lkn_bpmpi_expyear').value = expDate[1].replace(/\D/g, '')
 
+    // Preencher campos browser info para conformidade ELO 3DS
+    var userAgentEl = document.getElementById('lkn_bpmpi_device_useragent')
+    if (userAgentEl) {
+      userAgentEl.value = navigator.userAgent || ''
+    }
+    var screenWidthEl = document.getElementById('lkn_bpmpi_device_screenwidth')
+    if (screenWidthEl) {
+      screenWidthEl.value = (screen.width || window.innerWidth || 0).toString()
+    }
+    var screenHeightEl = document.getElementById('lkn_bpmpi_device_screenheight')
+    if (screenHeightEl) {
+      screenHeightEl.value = (screen.height || window.innerHeight || 0).toString()
+    }
+    var colorDepthEl = document.getElementById('lkn_bpmpi_device_colordepth')
+    if (colorDepthEl) {
+      colorDepthEl.value = (screen.colorDepth || 24).toString()
+    }
+    var timezoneEl = document.getElementById('lkn_bpmpi_device_timezone')
+    if (timezoneEl) {
+      timezoneEl.value = (new Date().getTimezoneOffset()).toString()
+    }
+    var javaEnabledEl = document.getElementById('lkn_bpmpi_device_javaenabled')
+    if (javaEnabledEl) {
+      javaEnabledEl.value = (typeof navigator.javaEnabled === 'function' && navigator.javaEnabled()) ? 'true' : 'false'
+    }
+
+    // Preencher campos billto com fallback DOM: billing → shipping → custom
+    // Phone com 3 camadas: billing-phone → shipping-phone → custom-phone
+    function getDomValueWithFallback(ids) {
+      for (var i = 0; i < ids.length; i++) {
+        var el = document.getElementById(ids[i])
+        if (el && el.value && el.value.trim() !== '') {
+          return el.value.trim()
+        }
+      }
+      return ''
+    }
+    function setIfExists(id, value) {
+      var el = document.getElementById(id)
+      if (el) el.value = value
+    }
+    setIfExists('lkn_bpmpi_billto_phonenumber', getDomValueWithFallback(['billing-phone', 'shipping-phone', 'custom-phone']))
+    setIfExists('lkn_bpmpi_billto_street1', getDomValueWithFallback(['billing-address_1', 'shipping-address_1']))
+    setIfExists('lkn_bpmpi_billto_street2', getDomValueWithFallback(['billing-address_2', 'shipping-address_2']))
+    setIfExists('lkn_bpmpi_billto_city', getDomValueWithFallback(['billing-city', 'shipping-city']))
+    setIfExists('lkn_bpmpi_billto_state', getDomValueWithFallback(['billing-state', 'shipping-state']))
+    setIfExists('lkn_bpmpi_billto_zipcode', getDomValueWithFallback(['billing-postcode', 'shipping-postcode']))
+    setIfExists('lkn_bpmpi_billto_country', getDomValueWithFallback(['billing-country', 'shipping-country']))
+    setIfExists('lkn_bpmpi_billto_email', getDomValueWithFallback(['billing-email', 'shipping-email']))
+    setIfExists('lkn_bpmpi_billto_contactname', getDomValueWithFallback(['billing-first_name']))
+    // Se o email do DOM não foi encontrado, manter o valor já existente no campo hidden
+
     bpmpi_authenticate()
   } catch (error) {
     resetLkn3DSStatus();

--- a/resources/js/frontend/lkn-dc-script-sdb.js
+++ b/resources/js/frontend/lkn-dc-script-sdb.js
@@ -348,6 +348,58 @@ function lknDCProccessButton() {
     document.getElementById('lkn_bpmpi_expmonth').value = expDate[0].replace(/\D/g, '')
     document.getElementById('lkn_bpmpi_expyear').value = expDate[1].replace(/\D/g, '')
 
+    // Preencher campos browser info para conformidade ELO 3DS
+    var userAgentEl = document.getElementById('lkn_bpmpi_device_useragent')
+    if (userAgentEl) {
+      userAgentEl.value = navigator.userAgent || ''
+    }
+    var screenWidthEl = document.getElementById('lkn_bpmpi_device_screenwidth')
+    if (screenWidthEl) {
+      screenWidthEl.value = (screen.width || window.innerWidth || 0).toString()
+    }
+    var screenHeightEl = document.getElementById('lkn_bpmpi_device_screenheight')
+    if (screenHeightEl) {
+      screenHeightEl.value = (screen.height || window.innerHeight || 0).toString()
+    }
+    var colorDepthEl = document.getElementById('lkn_bpmpi_device_colordepth')
+    if (colorDepthEl) {
+      colorDepthEl.value = (screen.colorDepth || 24).toString()
+    }
+    var timezoneEl = document.getElementById('lkn_bpmpi_device_timezone')
+    if (timezoneEl) {
+      timezoneEl.value = (new Date().getTimezoneOffset()).toString()
+    }
+    var javaEnabledEl = document.getElementById('lkn_bpmpi_device_javaenabled')
+    if (javaEnabledEl) {
+      javaEnabledEl.value = (typeof navigator.javaEnabled === 'function' && navigator.javaEnabled()) ? 'true' : 'false'
+    }
+
+    // Preencher campos billto com fallback DOM: billing → shipping → custom
+    // Phone com 3 camadas: billing-phone → shipping-phone → custom-phone
+    function getDomValueWithFallback(ids) {
+      for (var i = 0; i < ids.length; i++) {
+        var el = document.getElementById(ids[i])
+        if (el && el.value && el.value.trim() !== '') {
+          return el.value.trim()
+        }
+      }
+      return ''
+    }
+    function setIfExists(id, value) {
+      var el = document.getElementById(id)
+      if (el) el.value = value
+    }
+    setIfExists('lkn_bpmpi_billto_phonenumber', getDomValueWithFallback(['billing-phone', 'shipping-phone', 'custom-phone']))
+    setIfExists('lkn_bpmpi_billto_street1', getDomValueWithFallback(['billing-address_1', 'shipping-address_1']))
+    setIfExists('lkn_bpmpi_billto_street2', getDomValueWithFallback(['billing-address_2', 'shipping-address_2']))
+    setIfExists('lkn_bpmpi_billto_city', getDomValueWithFallback(['billing-city', 'shipping-city']))
+    setIfExists('lkn_bpmpi_billto_state', getDomValueWithFallback(['billing-state', 'shipping-state']))
+    setIfExists('lkn_bpmpi_billto_zipcode', getDomValueWithFallback(['billing-postcode', 'shipping-postcode']))
+    setIfExists('lkn_bpmpi_billto_country', getDomValueWithFallback(['billing-country', 'shipping-country']))
+    setIfExists('lkn_bpmpi_billto_email', getDomValueWithFallback(['billing-email', 'shipping-email']))
+    setIfExists('lkn_bpmpi_billto_contactname', getDomValueWithFallback(['billing-first_name']))
+    // Se o email do DOM não foi encontrado, manter o valor já existente no campo hidden
+
     bpmpi_authenticate()
   } catch (error) {
     resetLkn3DSStatus(); // Reset em caso de erro


### PR DESCRIPTION
# Cielo Payment Gateway for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, payment, paymethod, card, credit

Testado até: 6.9

Versão estável: 1.33.4

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartão de crédito, débito, Pix e Google Pay através da Cielo diretamente na sua loja WooCommerce.

## Descrição

Integre os gateways de pagamento da Cielo à sua loja WooCommerce e habilite seus clientes a pagarem via cartão de crédito, cartão de débito, Pix e Google Pay.

A [Cielo](https://www.cielo.com.br) é uma das maiores adquirentes do Brasil, oferecendo gateway seguro e eficiente para empresas aceitarem pagamentos online. O plugin oferece suporte completo aos métodos de pagamento da Cielo com autenticação 3DS 2.2 para cartões de débito e recursos avançados de parcelamento com juros/desconto.

**Recursos principais:**

- Cartão de Crédito com parcelamento inteligente
- Cartão de Débito com autenticação 3DS 2.2
- Pagamento via Pix
- Google Pay
- Cálculos de juros/desconto nos parcelamentos
- Compatibilidade com WooCommerce Blocks (Editor de Blocos)
- Layout responsivo e moderno
- Validação de BIN automática
- Suporte a múltiplas moedas

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Cielo Payment Gateway for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Cielo Payment Gateway for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os métodos Cielo desejados.
3. Configure suas credenciais da Cielo (MerchantId, MerchantKey).
4. Configure as opções de parcelamento e juros conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Cielo.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Ajuste: preenchimento dos campos necessários para o 3DS.
* Ajuste: verificação do nonce.