### PR TITLE
1.33.5 - wc_cielo_payment_gateway (Validação do 3DS)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "8.2"
-  DEPLOY_TAG: "1.33.4"
+  DEPLOY_TAG: "1.33.5"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "8.2"
-  DEPLOY_TAG: "1.33.4"
+  DEPLOY_TAG: "1.33.5"
 
 jobs:
   deploy-to-wp:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.33.5 - 24/06/2026
+* Ajuste: Validação do 3DS.
+  
 # 1.33.4 - 12/06/2026
 * Ajuste: verificação do nonce.
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
 Tags: pagamento, cielo, pix, woocommerce, creditcard
 Requires at least: 5.7
 Tested up to: 6.9
-Stable tag: 1.33.4
+Stable tag: 1.33.5
 Requires PHP: 8.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/README.txt
+++ b/README.txt
@@ -112,6 +112,10 @@ CIELO API PIX, credit card, debit payment for WooCommerceCIELO API PIX, credit c
 7. Debit card front page with payment fields.
 
 == Changelog ==
+= 1.33.5 =
+** 26/06/2026 **
+* Adjustment: 3DS validation.
+
 = 1.33.4 =
 ** 12/06/2026 **
 * Fix: Nonce verification.

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -1098,6 +1098,13 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
             $version = isset($_POST['lkn_cielo_3ds_version']) ? sanitize_text_field(wp_unslash($_POST['lkn_cielo_3ds_version'])) : '';
             $refId = isset($_POST['lkn_cielo_3ds_ref_id']) ? sanitize_text_field(wp_unslash($_POST['lkn_cielo_3ds_ref_id'])) : '';
 
+            // Normalize JS setAttribute pass-through values ('null', 'undefined', 'true') to empty strings
+            foreach (array('xid', 'cavv', 'eci', 'version', 'refId') as $field) {
+                if (in_array($$field, array('null', 'undefined', 'true'), true)) {
+                    $$field = '';
+                }
+            }
+
             // POST parameters
             $url = ($this->get_option('env') == 'production') ? 'https://api.cieloecommerce.cielo.com.br/' : 'https://apisandbox.cieloecommerce.cielo.com.br/';
             $merchantId = sanitize_text_field($this->get_option('merchant_id'));
@@ -1299,7 +1306,11 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
             $actualCapture = ($cardType === 'Debit') ? true : $capture;
 
             // Cartão de débito - verificar se permite cartão inelegível ou se tem validação 3DS
-            if ($this->get_option('allow_card_ineligible', 'no') == 'yes' && (empty($refId) || 'null' == $refId)) {
+            // Bypass 3DS when allowed AND: no 3DS was attempted, OR auth failed (cavv empty, not data-only ECI 04)
+            $bypass3ds = $this->get_option('allow_card_ineligible', 'no') == 'yes' && 
+                (empty($refId) || 'null' == $refId || (empty($cavv) && 4 != $eci));
+            
+            if ($bypass3ds) {
                 $args['headers'] = array(
                     'Content-Type' => 'application/json',
                     'MerchantId' => $merchantId,

--- a/lkn-wc-gateway-cielo-file.php
+++ b/lkn-wc-gateway-cielo-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('LKN_WC_CIELO_VERSION')) {
-    define('LKN_WC_CIELO_VERSION', '1.33.4');
+    define('LKN_WC_CIELO_VERSION', '1.33.5');
 }
 
 if (! defined('LKN_WC_CIELO_FILE')) {

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -16,7 +16,7 @@
  * Plugin Name:       CIELO API PIX, credit card, debit payment for WooCommerce
  * Plugin URI:        https://www.linknacional.com.br/wordpress/woocommerce/cielo/
  * Description:       Adds the Cielo API 3.0 Payments gateway to your WooCommerce website.
- * Version:           1.33.4
+ * Version:           1.33.5
  * Requires PHP:      8.2
  * Requires at least: 5.8
  * Author:            Link Nacional

--- a/resources/js/debitCard/lkn-dc-script-prd.js
+++ b/resources/js/debitCard/lkn-dc-script-prd.js
@@ -7,21 +7,21 @@ function bpmpi_config () {
     },
     onSuccess: function (e) {
       // Card is eligible for authentication, and the bearer successfully authenticated
-      const cavv = e.Cavv
-      const xid = e.Xid
-      const eci = e.Eci
-      const version = e.Version
-      const referenceId = e.ReferenceId
+      const cavv = e.Cavv || ''
+      const xid = e.Xid || ''
+      const eci = e.Eci || ''
+      const version = e.Version || ''
+      const referenceId = e.ReferenceId || ''
 
-      const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0].closest('form')
-
-      Form3dsButton.setAttribute('data-payment-cavv', cavv)
-      Form3dsButton.setAttribute('data-payment-eci', eci)
-      Form3dsButton.setAttribute('data-payment-ref_id', referenceId)
-      Form3dsButton.setAttribute('data-payment-version', version)
-      Form3dsButton.setAttribute('data-payment-xid', xid)
+      const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]?.closest('form')
 
       if (Form3dsButton) {
+        Form3dsButton.setAttribute('data-payment-cavv', cavv)
+        Form3dsButton.setAttribute('data-payment-eci', eci)
+        Form3dsButton.setAttribute('data-payment-ref_id', referenceId)
+        Form3dsButton.setAttribute('data-payment-version', version)
+        Form3dsButton.setAttribute('data-payment-xid', xid)
+
         const Button3ds = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
         const event = new MouseEvent('click', {
           bubbles: true,
@@ -37,41 +37,74 @@ function bpmpi_config () {
     onFailure: function (e) {
       console.log('code ' + e.ReturnCode + ' ' + ' message ' + e.ReturnMessage + ' raw: ' + JSON.stringify(e))
 
-      // Card is not eligible for authentication, but the bearer failed payment
-      alert(wp.i18n.__('Authentication failed check the card information and try again', 'lkn-wc-gateway-cielo'))
+      const allowCardIneligible = window.lknDCScriptAllowCardIneligible && window.lknDCScriptAllowCardIneligible.allow === 'yes'
+      if (allowCardIneligible) {
+        // User opted to continue even on 3DS failure — submit with whatever auth data we have
+        const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]?.closest('form')
+        if (Form3dsButton) {
+          Form3dsButton.setAttribute('data-payment-cavv', e.Cavv || '')
+          Form3dsButton.setAttribute('data-payment-eci', e.Eci || '')
+          Form3dsButton.setAttribute('data-payment-ref_id', e.ReferenceId || '')
+          Form3dsButton.setAttribute('data-payment-version', e.Version || '')
+          Form3dsButton.setAttribute('data-payment-xid', e.Xid || '')
+          const Button3ds = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
+          const event = new MouseEvent('click', { bubbles: true, cancelable: true, view: window })
+          Button3ds.dispatchEvent(event)
+        }
+      } else {
+        alert(wp.i18n.__('Authentication failed check the card information and try again', 'lkn-wc-gateway-cielo'))
+      }
     },
     onUnenrolled: function (e) {
       console.log('code ' + e.ReturnCode + ' ' + ' message ' + e.ReturnMessage + ' raw: ' + JSON.stringify(e))
 
-      // Verificar se a opção allow_card_ineligible está habilitada
-      const allowCardIneligible = window.lknDCScriptAllowCardIneligible.allow === 'yes'
+      // ECI 04/07 = Data Only = NÃO autenticada (risco do lojista). Requer allow_card_ineligible.
+      const allowCardIneligible = window.lknDCScriptAllowCardIneligible && window.lknDCScriptAllowCardIneligible.allow === 'yes'
       
       if (allowCardIneligible) {
-        // Continuar processamento sem 3DS - simular dados vazios
-        const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0].closest('form')
+        const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]?.closest('form')
         
-        Form3dsButton.setAttribute('data-payment-cavv', '')
-        Form3dsButton.setAttribute('data-payment-eci', '')
-        Form3dsButton.setAttribute('data-payment-ref_id', e.ReferenceId || '')
-        Form3dsButton.setAttribute('data-payment-version', e.Version || '')
-        Form3dsButton.setAttribute('data-payment-xid', '')
-        
-        // Clicar no botão de finalizar pedido
-        const Button3ds = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
-        const event = new MouseEvent('click', {
-          bubbles: true,
-          cancelable: true,
-          view: window
-        })
-        Button3ds.dispatchEvent(event)
+        if (Form3dsButton) {
+          Form3dsButton.setAttribute('data-payment-cavv', e.Cavv || '')
+          Form3dsButton.setAttribute('data-payment-eci', e.Eci || '')
+          Form3dsButton.setAttribute('data-payment-ref_id', e.ReferenceId || '')
+          Form3dsButton.setAttribute('data-payment-version', e.Version || '')
+          Form3dsButton.setAttribute('data-payment-xid', e.Xid || '')
+          
+          const Button3ds = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
+          const event = new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+            view: window
+          })
+          Button3ds.dispatchEvent(event)
+        }
       } else {
         // Card is not eligible for authentication (unauthenticable)
         alert(wp.i18n.__('Card Ineligible for Authentication', 'lkn-wc-gateway-cielo'))
       }
     },
-    onDisabled: function () {
+    onDisabled: function (e) {
       // Store don't require bearer authentication (class "bpmpi_auth" false -> disabled authentication).
-      alert(wp.i18n.__('Authentication disabled by the store', 'lkn-wc-gateway-cielo'))
+      console.log('code ' + (e ? e.ReturnCode : 'N/A') + ' ' + ' message ' + (e ? e.ReturnMessage : 'N/A') + ' raw: ' + JSON.stringify(e || {}))
+
+      const allowCardIneligible = window.lknDCScriptAllowCardIneligible && window.lknDCScriptAllowCardIneligible.allow === 'yes'
+      if (allowCardIneligible) {
+        // Continuar sem 3DS mas preservando dados do MPI (ECI pode ser útil para data-only)
+        const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]?.closest('form')
+        if (Form3dsButton) {
+          Form3dsButton.setAttribute('data-payment-cavv', '')
+          Form3dsButton.setAttribute('data-payment-eci', '')
+          Form3dsButton.setAttribute('data-payment-ref_id', '')
+          Form3dsButton.setAttribute('data-payment-version', '')
+          Form3dsButton.setAttribute('data-payment-xid', '')
+          const Button3ds = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
+          const event = new MouseEvent('click', { bubbles: true, cancelable: true, view: window })
+          Button3ds.dispatchEvent(event)
+        }
+      } else {
+        alert(wp.i18n.__('Authentication disabled by the store', 'lkn-wc-gateway-cielo'))
+      }
     },
     onError: function (e) {
       console.log('code ' + e.ReturnCode + ' ' + ' message ' + e.ReturnMessage + ' raw: ' + JSON.stringify(e))
@@ -82,8 +115,23 @@ function bpmpi_config () {
     onUnsupportedBrand: function (e) {
       console.log('code ' + e.ReturnCode + ' ' + ' message ' + e.ReturnMessage + ' raw: ' + JSON.stringify(e))
 
-      // Provider not supported for authentication
-      alert(wp.i18n.__('Provider not supported by Cielo 3DS authentication', 'lkn-wc-gateway-cielo'))
+      const allowCardIneligible = window.lknDCScriptAllowCardIneligible && window.lknDCScriptAllowCardIneligible.allow === 'yes'
+      if (allowCardIneligible) {
+        // Continuar sem 3DS
+        const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]?.closest('form')
+        if (Form3dsButton) {
+          Form3dsButton.setAttribute('data-payment-cavv', '')
+          Form3dsButton.setAttribute('data-payment-eci', '')
+          Form3dsButton.setAttribute('data-payment-ref_id', '')
+          Form3dsButton.setAttribute('data-payment-version', '')
+          Form3dsButton.setAttribute('data-payment-xid', '')
+          const Button3ds = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
+          const event = new MouseEvent('click', { bubbles: true, cancelable: true, view: window })
+          Button3ds.dispatchEvent(event)
+        }
+      } else {
+        alert(wp.i18n.__('Provider not supported by Cielo 3DS authentication', 'lkn-wc-gateway-cielo'))
+      }
     },
 
     Environment: 'PRD', // SDB ou PRD

--- a/resources/js/debitCard/lkn-dc-script-sdb.js
+++ b/resources/js/debitCard/lkn-dc-script-sdb.js
@@ -8,21 +8,21 @@ function bpmpi_config () {
     },
     onSuccess: function (e) {
       // Card is eligible for authentication, and the bearer successfully authenticated
-      const cavv = e.Cavv
-      const xid = e.Xid
-      const eci = e.Eci
-      const version = e.Version
-      const referenceId = e.ReferenceId
+      const cavv = e.Cavv || ''
+      const xid = e.Xid || ''
+      const eci = e.Eci || ''
+      const version = e.Version || ''
+      const referenceId = e.ReferenceId || ''
 
-      const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0].closest('form')
-
-      Form3dsButton.setAttribute('data-payment-cavv', cavv)
-      Form3dsButton.setAttribute('data-payment-eci', eci)
-      Form3dsButton.setAttribute('data-payment-ref_id', referenceId)
-      Form3dsButton.setAttribute('data-payment-version', version)
-      Form3dsButton.setAttribute('data-payment-xid', xid)
+      const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]?.closest('form')
 
       if (Form3dsButton) {
+        Form3dsButton.setAttribute('data-payment-cavv', cavv)
+        Form3dsButton.setAttribute('data-payment-eci', eci)
+        Form3dsButton.setAttribute('data-payment-ref_id', referenceId)
+        Form3dsButton.setAttribute('data-payment-version', version)
+        Form3dsButton.setAttribute('data-payment-xid', xid)
+
         const Button3ds = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
         const event = new MouseEvent('click', {
           bubbles: true,
@@ -38,41 +38,73 @@ function bpmpi_config () {
       // Card is not eligible for authentication, but the bearer failed payment
       console.log('code ' + e.ReturnCode + ' ' + ' message ' + e.ReturnMessage + ' raw: ' + JSON.stringify(e))
 
-      alert(wp.i18n.__('Authentication failed check the card information and try again', 'lkn-wc-gateway-cielo'))
+      const allowCardIneligible = window.lknDCScriptAllowCardIneligible && window.lknDCScriptAllowCardIneligible.allow === 'yes'
+      if (allowCardIneligible) {
+        const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]?.closest('form')
+        if (Form3dsButton) {
+          Form3dsButton.setAttribute('data-payment-cavv', e.Cavv || '')
+          Form3dsButton.setAttribute('data-payment-eci', e.Eci || '')
+          Form3dsButton.setAttribute('data-payment-ref_id', e.ReferenceId || '')
+          Form3dsButton.setAttribute('data-payment-version', e.Version || '')
+          Form3dsButton.setAttribute('data-payment-xid', e.Xid || '')
+          const Button3ds = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
+          const event = new MouseEvent('click', { bubbles: true, cancelable: true, view: window })
+          Button3ds.dispatchEvent(event)
+        }
+      } else {
+        alert(wp.i18n.__('Authentication failed check the card information and try again', 'lkn-wc-gateway-cielo'))
+      }
     },
     onUnenrolled: function (e) {
       console.log('code ' + e.ReturnCode + ' ' + ' message ' + e.ReturnMessage + ' raw: ' + JSON.stringify(e))
 
-      // Verificar se a opção allow_card_ineligible está habilitada
-      const allowCardIneligible = window.lknDCScriptAllowCardIneligible.allow === 'yes'
+      // ECI 04/07 = Data Only = NÃO autenticada (risco do lojista). Requer allow_card_ineligible.
+      const allowCardIneligible = window.lknDCScriptAllowCardIneligible && window.lknDCScriptAllowCardIneligible.allow === 'yes'
       
       if (allowCardIneligible) {
+        const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]?.closest('form')
         
-        // Continuar processamento sem 3DS - simular dados vazios
-        const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0].closest('form')
-        
-        Form3dsButton.setAttribute('data-payment-cavv', '')
-        Form3dsButton.setAttribute('data-payment-eci', '')
-        Form3dsButton.setAttribute('data-payment-ref_id', e.ReferenceId || '')
-        Form3dsButton.setAttribute('data-payment-version', e.Version || '')
-        Form3dsButton.setAttribute('data-payment-xid', '')
-        
-        // Clicar no botão de finalizar pedido
-        const Button3ds = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
-        const event = new MouseEvent('click', {
-          bubbles: true,
-          cancelable: true,
-          view: window
-        })
-        Button3ds.dispatchEvent(event)
+        if (Form3dsButton) {
+          Form3dsButton.setAttribute('data-payment-cavv', e.Cavv || '')
+          Form3dsButton.setAttribute('data-payment-eci', e.Eci || '')
+          Form3dsButton.setAttribute('data-payment-ref_id', e.ReferenceId || '')
+          Form3dsButton.setAttribute('data-payment-version', e.Version || '')
+          Form3dsButton.setAttribute('data-payment-xid', e.Xid || '')
+          
+          const Button3ds = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
+          const event = new MouseEvent('click', {
+            bubbles: true,
+            cancelable: true,
+            view: window
+          })
+          Button3ds.dispatchEvent(event)
+        }
       } else {
         // Card is not eligible for authentication (unauthenticable)
         alert(wp.i18n.__('Card Ineligible for Authentication', 'lkn-wc-gateway-cielo'))
       }
     },
-    onDisabled: function () {
+    onDisabled: function (e) {
       // Store don't require bearer authentication (class "bpmpi_auth" false -> disabled authentication).
-      alert(wp.i18n.__('Authentication disabled by the store', 'lkn-wc-gateway-cielo'))
+      console.log('code ' + (e ? e.ReturnCode : 'N/A') + ' ' + ' message ' + (e ? e.ReturnMessage : 'N/A') + ' raw: ' + JSON.stringify(e || {}))
+
+      const allowCardIneligible = window.lknDCScriptAllowCardIneligible && window.lknDCScriptAllowCardIneligible.allow === 'yes'
+      if (allowCardIneligible) {
+        // Continuar sem 3DS
+        const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]?.closest('form')
+        if (Form3dsButton) {
+          Form3dsButton.setAttribute('data-payment-cavv', '')
+          Form3dsButton.setAttribute('data-payment-eci', '')
+          Form3dsButton.setAttribute('data-payment-ref_id', '')
+          Form3dsButton.setAttribute('data-payment-version', '')
+          Form3dsButton.setAttribute('data-payment-xid', '')
+          const Button3ds = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
+          const event = new MouseEvent('click', { bubbles: true, cancelable: true, view: window })
+          Button3ds.dispatchEvent(event)
+        }
+      } else {
+        alert(wp.i18n.__('Authentication disabled by the store', 'lkn-wc-gateway-cielo'))
+      }
     },
     onError: function (e) {
       console.log('code ' + e.ReturnCode + ' ' + ' message ' + e.ReturnMessage + ' raw: ' + JSON.stringify(e))
@@ -83,8 +115,23 @@ function bpmpi_config () {
     onUnsupportedBrand: function (e) {
       console.log('code ' + e.ReturnCode + ' ' + ' message ' + e.ReturnMessage + ' raw: ' + JSON.stringify(e))
 
-      // Provider not supported for authentication
-      alert(wp.i18n.__('Provider not supported by Cielo 3DS authentication', 'lkn-wc-gateway-cielo'))
+      const allowCardIneligible = window.lknDCScriptAllowCardIneligible && window.lknDCScriptAllowCardIneligible.allow === 'yes'
+      if (allowCardIneligible) {
+        // Continuar sem 3DS
+        const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]?.closest('form')
+        if (Form3dsButton) {
+          Form3dsButton.setAttribute('data-payment-cavv', '')
+          Form3dsButton.setAttribute('data-payment-eci', '')
+          Form3dsButton.setAttribute('data-payment-ref_id', '')
+          Form3dsButton.setAttribute('data-payment-version', '')
+          Form3dsButton.setAttribute('data-payment-xid', '')
+          const Button3ds = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
+          const event = new MouseEvent('click', { bubbles: true, cancelable: true, view: window })
+          Button3ds.dispatchEvent(event)
+        }
+      } else {
+        alert(wp.i18n.__('Provider not supported by Cielo 3DS authentication', 'lkn-wc-gateway-cielo'))
+      }
     },
 
     Environment: 'SDB', // SDB or PRD

--- a/resources/js/frontend/lkn-dc-script-prd.js
+++ b/resources/js/frontend/lkn-dc-script-prd.js
@@ -192,11 +192,11 @@ function setupErrorDetection() {
 })(jQuery)
 
 function submitForm (e) {
-  const cavv = e.Cavv
-  const xid = e.Xid
-  const eci = e.Eci
-  const version = e.Version
-  const referenceId = e.ReferenceId
+  const cavv = e.Cavv || ''
+  const xid = e.Xid || ''
+  const eci = e.Eci || ''
+  const version = e.Version || ''
+  const referenceId = e.ReferenceId || ''
   const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]?.closest('form')
 
   // Marcar que 3DS foi completado
@@ -256,25 +256,29 @@ function bpmpi_config () {
 
       const lknDebitCCForm = document.getElementById('wc-lkn_cielo_debit-cc-form')
       if (lknDebitCCForm) {
-        alert(wp.i18n.__('Authentication failed check the card information and try again', 'lkn-wc-gateway-cielo'))
+        if(lknDCScriptAllowCardIneligible.allow == 'yes'){
+          submitForm(e)
+        }else{
+          alert(wp.i18n.__('Authentication failed check the card information and try again', 'lkn-wc-gateway-cielo'))
+        }
       }
     },
     onUnenrolled: function (e) {
       // Card is not eligible for authentication (unauthenticable)
       console.log('code ' + e.ReturnCode + ' ' + ' message ' + e.ReturnMessage)
-      //aqui
+      // ECI 04/07 = Data Only = NÃO autenticada. Requer allow_card_ineligible.
       if(lknDCScriptAllowCardIneligible.allow == 'yes'){
         submitForm(e)
       }else{
         alert(wp.i18n.__('Card Ineligible for Authentication', 'lkn-wc-gateway-cielo'))
       }
     },
-    onDisabled: function () {
+    onDisabled: function (e) {
       // Store don't require bearer authentication (class "bpmpi_auth" false -> disabled authentication).
-      console.log('code ' + e.ReturnCode + ' ' + ' message ' + e.ReturnMessage)
+      console.log('code ' + (e ? e.ReturnCode : 'N/A') + ' ' + ' message ' + (e ? e.ReturnMessage : 'N/A'))
       //aqui
       if(lknDCScriptAllowCardIneligible.allow == 'yes'){
-        submitForm(e)
+        submitForm(e || {})
       }else{
         alert(wp.i18n.__('Authentication disabled by the store', 'lkn-wc-gateway-cielo'))
       }

--- a/resources/js/frontend/lkn-dc-script-sdb.js
+++ b/resources/js/frontend/lkn-dc-script-sdb.js
@@ -199,11 +199,11 @@ function setupErrorDetection() {
 })(jQuery)
 
 function submitForm(e) {
-  const cavv = e.Cavv
-  const xid = e.Xid
-  const eci = e.Eci
-  const version = e.Version
-  const referenceId = e.ReferenceId
+  const cavv = e.Cavv || ''
+  const xid = e.Xid || ''
+  const eci = e.Eci || ''
+  const version = e.Version || ''
+  const referenceId = e.ReferenceId || ''
   const Form3dsButton = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]?.closest('form')
 
   // Marcar que 3DS foi completado
@@ -263,25 +263,29 @@ function bpmpi_config() {
 
       const lknDebitCCForm = document.getElementById('wc-lkn_cielo_debit-cc-form')
       if (lknDebitCCForm) {
-        alert(wp.i18n.__('Authentication failed check the card information and try again', 'lkn-wc-gateway-cielo'))
+        if (lknDCScriptAllowCardIneligible.allow == 'yes') {
+          submitForm(e)
+        } else {
+          alert(wp.i18n.__('Authentication failed check the card information and try again', 'lkn-wc-gateway-cielo'))
+        }
       }
     },
     onUnenrolled: function (e) {
       // Card is not eligible for authentication (unauthenticable)
       console.log('code ' + e.ReturnCode + ' ' + ' message ' + e.ReturnMessage)
-      //aqui
+      // ECI 04/07 = Data Only = NÃO autenticada. Requer allow_card_ineligible.
       if (lknDCScriptAllowCardIneligible.allow == 'yes') {
         submitForm(e)
       } else {
         alert(wp.i18n.__('Card Ineligible for Authentication', 'lkn-wc-gateway-cielo'))
       }
     },
-    onDisabled: function () {
+    onDisabled: function (e) {
       // Store don't require bearer authentication (class "bpmpi_auth" false -> disabled authentication).
-      console.log('code ' + e.ReturnCode + ' ' + ' message ' + e.ReturnMessage)
+      console.log('code ' + (e ? e.ReturnCode : 'N/A') + ' ' + ' message ' + (e ? e.ReturnMessage : 'N/A'))
       //aqui
       if (lknDCScriptAllowCardIneligible.allow == 'yes') {
-        submitForm(e)
+        submitForm(e || {})
       } else {
         alert(wp.i18n.__('Authentication disabled by the store', 'lkn-wc-gateway-cielo'))
       }


### PR DESCRIPTION
# Cielo Payment Gateway for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, payment, paymethod, card, credit

Testado até: 6.9

Versão estável: 1.33.5

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartão de crédito, débito, Pix e Google Pay através da Cielo diretamente na sua loja WooCommerce.

## Descrição

Integre os gateways de pagamento da Cielo à sua loja WooCommerce e habilite seus clientes a pagarem via cartão de crédito, cartão de débito, Pix e Google Pay.

A [Cielo](https://www.cielo.com.br) é uma das maiores adquirentes do Brasil, oferecendo gateway seguro e eficiente para empresas aceitarem pagamentos online. O plugin oferece suporte completo aos métodos de pagamento da Cielo com autenticação 3DS 2.2 para cartões de débito e recursos avançados de parcelamento com juros/desconto.

**Recursos principais:**

- Cartão de Crédito com parcelamento inteligente
- Cartão de Débito com autenticação 3DS 2.2
- Pagamento via Pix
- Google Pay
- Cálculos de juros/desconto nos parcelamentos
- Compatibilidade com WooCommerce Blocks (Editor de Blocos)
- Layout responsivo e moderno
- Validação de BIN automática
- Suporte a múltiplas moedas

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Cielo Payment Gateway for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Cielo Payment Gateway for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os métodos Cielo desejados.
3. Configure suas credenciais da Cielo (MerchantId, MerchantKey).
4. Configure as opções de parcelamento e juros conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Cielo.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Ajuste: Validação do 3DS.