### PR TITLE
1.33.5 - wc_cielo_payment_gateway (Validação do 3DS)

### DIFF
--- a/includes/LknWCGatewayCieloCredit.php
+++ b/includes/LknWCGatewayCieloCredit.php
@@ -682,6 +682,14 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway
         $cardCvv = isset($_POST['lkn_cc_cvc']) ? sanitize_text_field(wp_unslash($_POST['lkn_cc_cvc'])) : '';
         $cardName = isset($_POST['lkn_cc_cardholder_name']) ? sanitize_text_field(wp_unslash($_POST['lkn_cc_cardholder_name'])) : '';
         $cardName = apply_filters('lkn_wc_cielo_get_cardholder_name', $cardName, $this, $order);
+
+        // Fallback: se o nome do titular do cartão estiver vazio, usa o nome de cobrança do pedido
+        if (empty(trim($cardName))) {
+            $firstName = $order->get_billing_first_name();
+            $lastName = $order->get_billing_last_name();
+            $cardName = trim($firstName . ' ' . $lastName);
+        }
+
         $installments = (int) isset($_POST['lkn_cc_installments']) ? sanitize_text_field(wp_unslash($_POST['lkn_cc_installments'])) : 1;
 
         // POST parameters
@@ -832,6 +840,9 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway
 
         $body = array(
             'MerchantOrderId' => $merchantOrderId,
+            'Customer' => array(
+                'Name' => $cardName,
+            ),
             'Payment' => array(
                 'Type' => 'CreditCard',
                 'Amount' => (int) $amountFormated,
@@ -840,6 +851,7 @@ final class LknWCGatewayCieloCredit extends WC_Payment_Gateway
                 'SoftDescriptor' => $description,
                 'CreditCard' => array(
                     'CardNumber' => $cardNum,
+                    'Holder' => $cardName,
                     'ExpirationDate' => $cardExp,
                     'SecurityCode' => $cardCvv,
                     'SaveCard' => $saveCard,

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -1087,6 +1087,14 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
             $cardCvv = isset($_POST['lkn_dc_cvc']) ? sanitize_text_field(wp_unslash($_POST['lkn_dc_cvc'])) : '';
             $cardName = isset($_POST['lkn_dc_cardholder_name']) ? sanitize_text_field(wp_unslash($_POST['lkn_dc_cardholder_name'])) : '';
             $cardName = apply_filters('lkn_wc_cielo_get_cardholder_name', $cardName, $this, $order);
+
+            // Fallback: se o nome do titular do cartão estiver vazio, usa o nome de cobrança do pedido
+            if (empty(trim($cardName))) {
+                $firstName = $order->get_billing_first_name();
+                $lastName = $order->get_billing_last_name();
+                $cardName = trim($firstName . ' ' . $lastName);
+            }
+
             $cardType = isset($_POST['lkn_cc_type']) ? sanitize_text_field(wp_unslash($_POST['lkn_cc_type'])) : '';
             $installments = (int) (isset($_POST['lkn_cc_dc_installments']) ? sanitize_text_field(wp_unslash($_POST['lkn_cc_dc_installments'])) : 1);
             $saveCard = isset($_POST['lkn_save_debit_credit_card']) && ($_POST['lkn_save_debit_credit_card'] === '1' || $this->get_option('save_card_token') == 'required' ) ? true : false;
@@ -1320,6 +1328,9 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
                 
                 $body = array(
                     'MerchantOrderId' => $merchantOrderId,
+                    'Customer' => array(
+                        'Name' => $cardName,
+                    ),
                     'Payment' => array(
                         'Type' => $cardType . "Card",
                         'Amount' => (int) $amountFormated,
@@ -1328,6 +1339,7 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
                         'SoftDescriptor' => $description,
                         $cardType . "Card" => array(
                             'CardNumber' => $cardNum,
+                            'Holder' => $cardName,
                             'ExpirationDate' => $cardExp,
                             'SecurityCode' => $cardCvv,
                             'Brand' => $provider,
@@ -1545,6 +1557,9 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
     
                 $body = array(
                     'MerchantOrderId' => sanitize_text_field($order_id . '-' . time()),
+                    'Customer' => array(
+                        'Name' => $cardName,
+                    ),
                     'Payment' => array(
                         'Type' => "CreditCard",
                         'Amount' => (int) number_format($order->get_total(), 2, '', ''),


### PR DESCRIPTION
# Cielo Payment Gateway for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, payment, paymethod, card, credit

Testado até: 6.9

Versão estável: 1.33.5

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartão de crédito, débito, Pix e Google Pay através da Cielo diretamente na sua loja WooCommerce.

## Descrição

Integre os gateways de pagamento da Cielo à sua loja WooCommerce e habilite seus clientes a pagarem via cartão de crédito, cartão de débito, Pix e Google Pay.

A [Cielo](https://www.cielo.com.br) é uma das maiores adquirentes do Brasil, oferecendo gateway seguro e eficiente para empresas aceitarem pagamentos online. O plugin oferece suporte completo aos métodos de pagamento da Cielo com autenticação 3DS 2.2 para cartões de débito e recursos avançados de parcelamento com juros/desconto.

**Recursos principais:**

- Cartão de Crédito com parcelamento inteligente
- Cartão de Débito com autenticação 3DS 2.2
- Pagamento via Pix
- Google Pay
- Cálculos de juros/desconto nos parcelamentos
- Compatibilidade com WooCommerce Blocks (Editor de Blocos)
- Layout responsivo e moderno
- Validação de BIN automática
- Suporte a múltiplas moedas

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Cielo Payment Gateway for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Cielo Payment Gateway for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os métodos Cielo desejados.
3. Configure suas credenciais da Cielo (MerchantId, MerchantKey).
4. Configure as opções de parcelamento e juros conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Cielo.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Ajuste: Validação do 3DS.