### PR TITLE
1.36.0 - wc_cielo_payment_gateway (Novo recurso para gerar ou não o botão de finalizar pedido no gateway de debit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 1.36.0 - 07/08/2026
+# 1.36.0 - 11/08/2026
 * Correção: Ajuste no warning referente ao tipo de cartão ao salvar metadados no gateway de pagamento exclusivo de crédito.
 * Novo: Opção para exibir ou ocultar o botão de finalizar pedido no gateway de pagamento de débito/crédito.
+* Correção: Ajuste na validação de carregamento do gateway de pagamento de débito no order-pay.
   
 # 1.35.1 - 04/08/2026
 * Ajuste: correção no sistema de 3DS.

--- a/README.txt
+++ b/README.txt
@@ -118,9 +118,10 @@ CIELO API PIX, credit card, debit payment for WooCommerceCIELO API PIX, credit c
 == Changelog ==
 
 = 1.36.0 =
-** 07/08/2026 **
+** 11/08/2026 **
 * Fix: Adjusted the card type warning when saving metadata in the credit-only payment gateway.
 * New: Option to show or hide the checkout button in the debit/credit payment gateway.
+* Fix: Adjusted the loading validation for the debit payment gateway on order-pay.
 
 = 1.35.1 =
 ** 04/08/2026 **

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -112,7 +112,11 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
         }
 
         if (\WC()->cart && \WC()->cart->total <= 0) {
-            
+            // Allow on order-pay page (cart may be empty, order total is separate)
+            if (is_checkout_pay_page()) {
+                return true;
+            }
+
             if (class_exists('\WC_Subscriptions_Cart') && \WC_Subscriptions_Cart::cart_contains_subscription()) { 
                 return true; // Permite checkout de assinatura com trial gratuito 
             } 


### PR DESCRIPTION
# Cielo Payment Gateway for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, payment, paymethod, card, credit

Testado até: 7.0

Versão estável: 1.36.0

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartão de crédito, débito, Pix e Google Pay através da Cielo diretamente na sua loja WooCommerce.

## Descrição

Integre os gateways de pagamento da Cielo à sua loja WooCommerce e habilite seus clientes a pagarem via cartão de crédito, cartão de débito, Pix e Google Pay.

A [Cielo](https://www.cielo.com.br) é uma das maiores adquirentes do Brasil, oferecendo gateway seguro e eficiente para empresas aceitarem pagamentos online. O plugin oferece suporte completo aos métodos de pagamento da Cielo com autenticação 3DS 2.2 para cartões de débito e recursos avançados de parcelamento com juros/desconto.

**Recursos principais:**

- Cartão de Crédito com parcelamento inteligente
- Cartão de Débito com autenticação 3DS 2.2
- Pagamento via Pix
- Google Pay
- Cálculos de juros/desconto nos parcelamentos
- Compatibilidade com WooCommerce Blocks (Editor de Blocos)
- Layout responsivo e moderno
- Validação de BIN automática
- Suporte a múltiplas moedas

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Cielo Payment Gateway for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Cielo Payment Gateway for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os métodos Cielo desejados.
3. Configure suas credenciais da Cielo (MerchantId, MerchantKey).
4. Configure as opções de parcelamento e juros conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Cielo.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Correção: Ajuste no warning referente ao tipo de cartão ao salvar metadados no gateway de pagamento exclusivo de crédito.
* Novo: Opção para exibir ou ocultar o botão de finalizar pedido no gateway de pagamento de débito/crédito.
* Correção: Ajuste na validação de carregamento do gateway de pagamento de débito no order-pay.