### PR TITLE
1.36.2 - wc_cielo_payment_gateway (Alerta de juros para pagamentos à vista)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "8.2"
-  DEPLOY_TAG: "1.36.1"
+  DEPLOY_TAG: "1.36.2"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "8.2"
-  DEPLOY_TAG: "1.36.1"
+  DEPLOY_TAG: "1.36.2"
 
 jobs:
   deploy-to-wp:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,4 +446,4 @@ composer test:unit   # Apenas testes unitários
 
 ---
 
-*Última atualização: análise da v1.36.1 — 2026. Este documento reflete os padrões observados no código e as correções de anti-padrões identificados.*
+*Última atualização: análise da v1.36.2 — 2026. Este documento reflete os padrões observados no código e as correções de anti-padrões identificados.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.36.2 - 13/08/2026
+* Adicionado: Alerta para pagamento à vista com juros.
+  
 # 1.36.1 - 12/08/2026
 * Correção: Ajuste no sistema de geração de juros/parcelas.
   

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
 Tags: pagamento, cielo, pix, woocommerce, creditcard
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 1.36.1
+Stable tag: 1.36.2
 Requires PHP: 8.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/README.txt
+++ b/README.txt
@@ -117,6 +117,10 @@ CIELO API PIX, credit card, debit payment for WooCommerceCIELO API PIX, credit c
 
 == Changelog ==
 
+= 1.36.2 =
+** 13/08/2026 **
+* Added: Alert for upfront payment with interest.
+
 = 1.36.1 =
 ** 12/08/2026 **
 * Fix: Adjustment to the interest/installment generation system.

--- a/lkn-wc-gateway-cielo-file.php
+++ b/lkn-wc-gateway-cielo-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('LKN_WC_CIELO_VERSION')) {
-    define('LKN_WC_CIELO_VERSION', '1.36.1');
+    define('LKN_WC_CIELO_VERSION', '1.36.2');
 }
 
 if (! defined('LKN_WC_CIELO_FILE')) {

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -16,7 +16,7 @@
  * Plugin Name:       CIELO API PIX, credit card, debit payment for WooCommerce
  * Plugin URI:        https://www.linknacional.com.br/wordpress/woocommerce/cielo/
  * Description:       Adds the Cielo API 3.0 Payments gateway to your WooCommerce website.
- * Version:           1.36.1
+ * Version:           1.36.2
  * Requires PHP:      8.2
  * Requires at least: 5.8
  * Author:            Link Nacional

--- a/resources/css/frontend/lkn-admin-layout.css
+++ b/resources/css/frontend/lkn-admin-layout.css
@@ -206,3 +206,82 @@
         margin-left: 0px;
     }
 }
+
+/* Aviso de juros na 1ª parcela */
+.lkn-cielo-info-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    margin-left: 6px;
+    vertical-align: middle;
+    position: relative;
+    cursor: pointer;
+    color: #2271b1;
+}
+
+.lkn-cielo-info-icon svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.lkn-cielo-info-tooltip {
+    position: absolute;
+    bottom: calc(100% + 10px);
+    left: 50%;
+    transform: translateX(-50%);
+    width: 300px;
+    max-width: calc(100vw - 40px);
+    padding: 10px 12px;
+    background: #fff;
+    color: #1d2327;
+    border: 1px solid #c3c4c7;
+    border-radius: 6px;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+    font-size: 12px;
+    line-height: 1.5;
+    font-weight: 400;
+    text-align: left;
+    white-space: normal;
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.15s ease, visibility 0.15s ease;
+    z-index: 1000;
+    pointer-events: none;
+}
+
+.lkn-cielo-info-tooltip::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: #fff;
+}
+
+.lkn-cielo-info-icon:hover .lkn-cielo-info-tooltip,
+.lkn-cielo-info-icon.is-open .lkn-cielo-info-tooltip {
+    visibility: visible;
+    opacity: 1;
+}
+
+.lkn-cielo-onex-recommendation {
+    margin-top: 4px !important;
+    padding: 6px 10px;
+    color: #7a5b00;
+    background: #fcf9e8;
+    border-left: 3px solid #dba617;
+    border-radius: 2px;
+    font-size: 12px;
+}
+
+@media (max-width: 782px) {
+    .lkn-cielo-info-tooltip {
+        left: 0;
+        transform: none;
+        width: 240px;
+    }
+}

--- a/resources/js/admin/lkn-wc-gateway-admin-layout.js
+++ b/resources/js/admin/lkn-wc-gateway-admin-layout.js
@@ -836,8 +836,76 @@
     })
 
     $('#lknWcCieloCreditBlocksSettingsLayoutDiv').append(message).css('display', 'table')
+
+    // Aviso sobre juros na parcela 1x (aplicado após a geração do layout)
+    lknWcCieloAddOnexInterestWarning()
+
     document.dispatchEvent(new Event('lknWcCieloFinishedAdminLayout'))
   })
+
+  function lknWcCieloAddOnexInterestWarning() {
+    // Campo de juros da 1ª parcela (não o de desconto)
+    const onexInput = document.querySelector('input[id$="_1x"]')
+    if (!onexInput) return
+
+    const bodyDiv = onexInput.closest('.lkn-body-cart')
+    const fieldset = onexInput.closest('fieldset')
+    const headerDiv = fieldset ? fieldset.querySelector('.lkn-header-cart') : null
+    if (!bodyDiv || !headerDiv) return
+
+    // Evita aplicar duas vezes
+    if (fieldset.querySelector('.lkn-cielo-onex-warning')) return
+
+    // Ícone de info + balão customizado (hover no desktop, toque/clique no mobile)
+    const icon = document.createElement('span')
+    icon.className = 'lkn-cielo-info-icon lkn-cielo-onex-warning'
+    icon.setAttribute('tabindex', '0')
+    icon.setAttribute('role', 'button')
+    icon.setAttribute('aria-label', 'Informações sobre juros na primeira parcela')
+    icon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/></svg>'
+
+    const tooltip = document.createElement('span')
+    tooltip.className = 'lkn-cielo-info-tooltip'
+    tooltip.setAttribute('role', 'tooltip')
+    tooltip.textContent = 'No Brasil, adicionar juros ou cobrar um valor maior no pagamento à vista (em 1 parcela) no cartão de crédito vai contra a lei e é considerado uma prática abusiva pelo Código de Defesa do Consumidor e órgãos de proteção (como os Procons).'
+    icon.appendChild(tooltip)
+
+    icon.addEventListener('mouseenter', function () { icon.classList.add('is-open') })
+    icon.addEventListener('mouseleave', function () { icon.classList.remove('is-open') })
+    icon.addEventListener('click', function (e) {
+      e.stopPropagation()
+      icon.classList.toggle('is-open')
+    })
+    icon.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        icon.classList.toggle('is-open')
+      }
+    })
+
+    document.addEventListener('click', function (e) {
+      if (!icon.contains(e.target)) icon.classList.remove('is-open')
+    })
+
+    // Insere o ícone ao lado do título do card
+    const titleEl = headerDiv.querySelector('div')
+    if (titleEl) {
+      titleEl.appendChild(icon)
+    } else {
+      headerDiv.appendChild(icon)
+    }
+
+    // Recomendação junto à descrição do campo
+    const descP = bodyDiv.querySelector('p.description')
+    const recommendation = document.createElement('p')
+    recommendation.className = 'description lkn-cielo-onex-recommendation lkn-cielo-onex-warning'
+    recommendation.textContent = 'Recomendação: Para pagamento à vista é sugerido que aplique sem juros.'
+    if (descP) {
+      descP.insertAdjacentElement('afterend', recommendation)
+    } else {
+      bodyDiv.appendChild(recommendation)
+    }
+  }
 
   function lknWcCieloValidateMerchantInputs() {
     const urlParams = new URLSearchParams(window.location.search)


### PR DESCRIPTION
# Cielo Payment Gateway for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, payment, paymethod, card, credit

Testado até: 7.0

Versão estável: 1.36.2

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartão de crédito, débito, Pix e Google Pay através da Cielo diretamente na sua loja WooCommerce.

## Descrição

Integre os gateways de pagamento da Cielo à sua loja WooCommerce e habilite seus clientes a pagarem via cartão de crédito, cartão de débito, Pix e Google Pay.

A [Cielo](https://www.cielo.com.br) é uma das maiores adquirentes do Brasil, oferecendo gateway seguro e eficiente para empresas aceitarem pagamentos online. O plugin oferece suporte completo aos métodos de pagamento da Cielo com autenticação 3DS 2.2 para cartões de débito e recursos avançados de parcelamento com juros/desconto.

**Recursos principais:**

- Cartão de Crédito com parcelamento inteligente
- Cartão de Débito com autenticação 3DS 2.2
- Pagamento via Pix
- Google Pay
- Cálculos de juros/desconto nos parcelamentos
- Compatibilidade com WooCommerce Blocks (Editor de Blocos)
- Layout responsivo e moderno
- Validação de BIN automática
- Suporte a múltiplas moedas

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Cielo Payment Gateway for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Cielo Payment Gateway for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os métodos Cielo desejados.
3. Configure suas credenciais da Cielo (MerchantId, MerchantKey).
4. Configure as opções de parcelamento e juros conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Cielo.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Adicionado: Alerta para pagamento à vista com juros.