### PR TITLE
1.36.3 - wc_cielo_payment_gateway (Ajuste na geração do token de autenticação 3DS)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "8.2"
-  DEPLOY_TAG: "1.36.2"
+  DEPLOY_TAG: "1.36.3"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "8.2"
-  DEPLOY_TAG: "1.36.2"
+  DEPLOY_TAG: "1.36.3"
 
 jobs:
   deploy-to-wp:

--- a/.reasonix/skills/prepare-release.md
+++ b/.reasonix/skills/prepare-release.md
@@ -1,6 +1,6 @@
 ---
 name: prepare-release
-description: Prepara release do lkn-wc-gateway-cielo: atualiza README.txt, CHANGELOG.md, cabeçalho PHP, constante LKN_WC_CIELO_VERSION e DEPLOY_TAG dos workflows baseado no git log
+description: Prepara release do lkn-wc-gateway-cielo: atualiza README.txt, CHANGELOG.md, cabeçalho PHP, constante LKN_WC_CIELO_VERSION, DEPLOY_TAG dos workflows e a versão no AGENTS.md baseado no git log
 ---
 
 # prepare-release
@@ -35,7 +35,7 @@ Só se não for possível ler o diff, use os comentários dos commits como pista
 
 ### 3. Atualizar TODOS os arquivos com versão
 
-A versão aparece em **6 locais** espalhados por **6 arquivos**. Atualize todos:
+A versão aparece em **7 locais** espalhados por **7 arquivos**. Atualize todos:
 
 #### 3a. `README.txt` (ATENÇÃO: maiúsculo, NÃO é `readme.txt`)
 - `Stable tag:` → nova versão
@@ -74,6 +74,9 @@ A versão aparece em **6 locais** espalhados por **6 arquivos**. Atualize todos:
 #### 3f. `.github/workflows/wordpressRelease.yml`
 - `DEPLOY_TAG: "NOVA_VERSION"`
 
+#### 3g. `AGENTS.md`
+- Atualizar a linha de rodapé `*Última atualização: análise da vX.Y.Z — ...*` para a nova versão (substituir só o número, preservando o restante da linha).
+
 ### 4. Validação final
 Rodar grep com a versão **antiga** para confirmar que não restou nenhuma ocorrência fora do esperado:
 ```
@@ -81,7 +84,7 @@ grep -r "VERSAO_ANTIGA" --include="*.php" --include="*.md" --include="*.txt" --i
 ```
 O esperado: `README.txt` e `CHANGELOG.md` ainda contêm a versão antiga **apenas** nas entradas antigas do Changelog (isso é correto). Qualquer outro arquivo retornando a versão antiga é **erro** e deve ser corrigido.
 
-Depois, grep com a versão **nova** para confirmar que aparece em todos os **6 locais**:
+Depois, grep com a versão **nova** para confirmar que aparece em todos os **7 locais**:
 ```
 grep -rn "NOVA_VERSAO" --include="*.php" --include="*.md" --include="*.txt" --include="*.yml" .
 ```
@@ -99,3 +102,4 @@ grep -rn "NOVA_VERSAO" --include="*.php" --include="*.md" --include="*.txt" --in
 - **Requires at least / Requires PHP**: devem existir **tanto** no cabeçalho PHP (`lkn-wc-gateway-cielo.php`) quanto no `README.txt`, com valores idênticos (WP mínimo `5.8`, PHP mínimo `8.2`).
 - **Datas de release**: fuso `America/Sao_Paulo`. Tanto `README.txt` quanto `CHANGELOG.md` usam `dd/mm/aaaa`.
 - **Assets do WP.org**: ficam em `resources/assets/wordpressAssets` (referenciado no `wordpressRelease.yml` como `ASSETS_DIR`).
+- **`AGENTS.md`**: a versão aparece apenas na linha de rodapé `*Última atualização: análise da vX.Y.Z — ...*` no final do arquivo. Atualize o número nessa linha a cada release (é o único ponto de versão no AGENTS.md).

--- a/.reasonix/skills/prepare-release.md
+++ b/.reasonix/skills/prepare-release.md
@@ -1,0 +1,101 @@
+---
+name: prepare-release
+description: Prepara release do lkn-wc-gateway-cielo: atualiza README.txt, CHANGELOG.md, cabeçalho PHP, constante LKN_WC_CIELO_VERSION e DEPLOY_TAG dos workflows baseado no git log
+---
+
+# prepare-release
+
+Atualiza **todos** os arquivos que contêm o número de versão para uma nova release do plugin.
+
+## Parâmetros (via `arguments`)
+
+O usuário pode passar os valores diretamente: `"version=1.37.0 tested_up=7.0 php=8.2 wp_min=5.8 highlights=Correção de bug X"`. Se algum valor faltar, pergunte.
+
+- **version** — nova versão (Stable tag)
+- **tested_up** — versão do WP testada (Tested up to)
+- **php** — versão mínima do PHP (Requires PHP)
+- **wp_min** — versão mínima do WordPress (Requires at least; default 5.8)
+- **highlights** — resumo da versão (opcional, usa git log se vazio)
+
+## Fluxo de execução
+
+### 1. Coletar valores
+Se não recebidos via arguments, pergunte ao usuário um por um. Detecte a versão atual via grep no `.php` raiz:
+```
+grep -E "Version:|LKN_WC_CIELO_VERSION" *.php
+```
+
+### 2. Analisar as mudanças reais (NÃO copiar os comentários dos commits)
+Os bullets do changelog devem descrever o **efeito real** das mudanças, não o texto dos `git log`.
+1. Liste os arquivos alterados: `git diff --stat ${LAST_TAG}..HEAD`
+2. Leia o diff dos arquivos de código: `git diff ${LAST_TAG}..HEAD -- includes/ *.php`
+3. Escreva cada bullet como "o que mudou para o usuário", ex.: "não exige mais 3DS para cartões sem suporte" em vez de "correção na verificação dos campos".
+
+Só se não for possível ler o diff, use os comentários dos commits como pista — nunca como texto final.
+
+### 3. Atualizar TODOS os arquivos com versão
+
+A versão aparece em **6 locais** espalhados por **6 arquivos**. Atualize todos:
+
+#### 3a. `README.txt` (ATENÇÃO: maiúsculo, NÃO é `readme.txt`)
+- `Stable tag:` → nova versão
+- `Tested up to:` e `Requires PHP:` se alterados
+- `Requires at least:` se alterado (versão mínima do WP)
+- Adicionar entrada no topo da seção `== Changelog ==`, **em inglês**, preservando o formato atual:
+  ```
+  = 1.37.0 =
+  ** 13/08/2026 **
+  * Added: ...
+
+  = 1.36.2 =
+  ```
+  (formato clássico do WP.org: `= VERSION =` + linha `** dd/mm/aaaa **` + bullets + linha em branco antes da versão anterior)
+- Se `highlights` foi fornecido, avalie adicionar na `== Description ==` (NUNCA apague conteúdo existente)
+
+#### 3b. `CHANGELOG.md`
+- Adicionar entrada no topo do arquivo, **em português**, no formato atual (`# VERSION - dd/mm/aaaa` + bullets + linha em branco):
+  ```
+  # 1.37.0 - 13/08/2026
+  * Adicionado: ...
+
+  # 1.36.2 - 13/08/2026
+  ```
+
+#### 3c. `lkn-wc-gateway-cielo.php`
+- `* Version: NOVA_VERSION` (cabeçalho do plugin)
+- `* Requires at least:` e `* Requires PHP:` — manter em sincronia com o `README.txt`
+
+#### 3d. `lkn-wc-gateway-cielo-file.php`
+- `define( 'LKN_WC_CIELO_VERSION', 'NOVA_VERSION' );` (constante)
+
+#### 3e. `.github/workflows/main.yml`
+- `DEPLOY_TAG: "NOVA_VERSION"`
+
+#### 3f. `.github/workflows/wordpressRelease.yml`
+- `DEPLOY_TAG: "NOVA_VERSION"`
+
+### 4. Validação final
+Rodar grep com a versão **antiga** para confirmar que não restou nenhuma ocorrência fora do esperado:
+```
+grep -r "VERSAO_ANTIGA" --include="*.php" --include="*.md" --include="*.txt" --include="*.yml" .
+```
+O esperado: `README.txt` e `CHANGELOG.md` ainda contêm a versão antiga **apenas** nas entradas antigas do Changelog (isso é correto). Qualquer outro arquivo retornando a versão antiga é **erro** e deve ser corrigido.
+
+Depois, grep com a versão **nova** para confirmar que aparece em todos os **6 locais**:
+```
+grep -rn "NOVA_VERSAO" --include="*.php" --include="*.md" --include="*.txt" --include="*.yml" .
+```
+
+## Observações específicas deste plugin
+- **Slug/pasta/arquivo**: `lkn-wc-gateway-cielo` (com hífens). NÃO renomear. O `.php` principal é `lkn-wc-gateway-cielo.php` e a constante fica em `lkn-wc-gateway-cielo-file.php`.
+- **`LKN_WC_CIELO_VERSION`**: é a constante usada em todo o plugin. Deve ficar **igual** ao `* Version:` do cabeçalho. O valor de versionamento é lido daqui pelo `LknWCCieloPayment` (`includes/LknWCCieloPayment.php`).
+- **Fallback hardcoded**: `includes/LknWCCieloPayment.php:102` tem `$this->version = '1.25.0';` como fallback quando `LKN_WC_CIELO_VERSION` não está definida. É apenas fallback e **não** precisa ser atualizado a cada release (a constante sempre é definida antes).
+- **`README.txt` é MAIÚSCULO** (diferente de `readme.txt`). O campo de versão fica lá; `README.md` **não** tem campo de versão explícito — não editar.
+- `composer.json` **não** tem campo `version` — não editar.
+- `package.json` tem `"version": "1.0.0"` mas é boilerplate do docker-php-dev-container — **não** editar (não é a versão do plugin).
+- **Apenas 2 workflows** com `DEPLOY_TAG`: `main.yml` (gera release no GitHub) e `wordpressRelease.yml` (deploy no WP.org). NÃO existe `dev-release.yml`.
+- O changelog do `README.txt` usa formato `= VERSION =` + `** dd/mm/aaaa **` (WordPress clássico), **diferente** do `CHANGELOG.md` que usa `# VERSION - dd/mm/aaaa`.
+- **Idioma do changelog**: `README.txt` → inglês; `CHANGELOG.md` → português.
+- **Requires at least / Requires PHP**: devem existir **tanto** no cabeçalho PHP (`lkn-wc-gateway-cielo.php`) quanto no `README.txt`, com valores idênticos (WP mínimo `5.8`, PHP mínimo `8.2`).
+- **Datas de release**: fuso `America/Sao_Paulo`. Tanto `README.txt` quanto `CHANGELOG.md` usam `dd/mm/aaaa`.
+- **Assets do WP.org**: ficam em `resources/assets/wordpressAssets` (referenciado no `wordpressRelease.yml` como `ASSETS_DIR`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,4 +446,4 @@ composer test:unit   # Apenas testes unitários
 
 ---
 
-*Última atualização: análise da v1.36.2 — 2026. Este documento reflete os padrões observados no código e as correções de anti-padrões identificados.*
+*Última atualização: análise da v1.36.3 — 2026. Este documento reflete os padrões observados no código e as correções de anti-padrões identificados.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.36.3 - 18/08/2026
+* Correção: Ajuste na geração do token de autenticação 3DS.
+
 # 1.36.2 - 13/08/2026
 * Adicionado: Alerta para pagamento à vista com juros.
   

--- a/README.txt
+++ b/README.txt
@@ -2,9 +2,9 @@
 Contributors: linknacional
 Donate link: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
 Tags: pagamento, cielo, pix, woocommerce, creditcard
-Requires at least: 5.8
-Tested up to: 7.0
-Stable tag: 1.36.2
+Requires at least: 6.0
+Tested up to: 7.1
+Stable tag: 1.36.3
 Requires PHP: 8.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -116,6 +116,10 @@ CIELO API PIX, credit card, debit payment for WooCommerceCIELO API PIX, credit c
 7. Debit card front page with payment fields.
 
 == Changelog ==
+
+= 1.36.3 =
+** 18/08/2026 **
+* Fix: Adjusted 3DS authentication token generation.
 
 = 1.36.2 =
 ** 13/08/2026 **

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -919,7 +919,9 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
         $fees_total = number_format($this->get_fees_total(), 2, '.', '');
         $taxes_total = number_format($this->get_taxes_total(), 2, '.', '');
         $discounts_total = number_format($this->get_discounts_total(), 2, '.', '');
-        $accessToken = isset($this->accessToken) ? $this->accessToken : array('access_token' => '', 'expires_in' => 0);
+        $accessToken = (! empty($this->accessToken) && is_array($this->accessToken) && ! empty($this->accessToken['access_token']))
+            ? $this->accessToken
+            : array('access_token' => '', 'expires_in' => 0);
         $url = get_page_link();
         $nonce = wp_create_nonce('nonce_lkn_cielo_debit');
         $placeholder = $this->get_option('placeholder', 'no');

--- a/includes/LknWCGatewayCieloEndpoint.php
+++ b/includes/LknWCGatewayCieloEndpoint.php
@@ -252,6 +252,14 @@ final class LknWCGatewayCieloEndpoint
         $LknWCGatewayCieloDebitClass = new LknWCGatewayCieloDebit();
         $acessToken = $LknWCGatewayCieloDebitClass->generate_debit_auth_token();
 
+        if (empty($acessToken) || ! is_array($acessToken) || empty($acessToken['access_token'])) {
+            return new WP_Error(
+                'token_generation_failed',
+                __('Auth token generation failed.', 'lkn-wc-gateway-cielo'),
+                array('status' => 502)
+            );
+        }
+
         return new WP_REST_Response($acessToken, 200);
     }
 

--- a/lkn-wc-gateway-cielo-file.php
+++ b/lkn-wc-gateway-cielo-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('LKN_WC_CIELO_VERSION')) {
-    define('LKN_WC_CIELO_VERSION', '1.36.2');
+    define('LKN_WC_CIELO_VERSION', '1.36.3');
 }
 
 if (! defined('LKN_WC_CIELO_FILE')) {

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -16,9 +16,9 @@
  * Plugin Name:       CIELO API PIX, credit card, debit payment for WooCommerce
  * Plugin URI:        https://www.linknacional.com.br/wordpress/woocommerce/cielo/
  * Description:       Adds the Cielo API 3.0 Payments gateway to your WooCommerce website.
- * Version:           1.36.2
+ * Version:           1.36.3
  * Requires PHP:      8.2
- * Requires at least: 5.8
+ * Requires at least: 6.0
  * Author:            Link Nacional
  * Author URI:        https://linknacional.com.br
  * Text Domain:       lkn-wc-gateway-cielo

--- a/resources/js/frontend/lkn-fix-token-script.js
+++ b/resources/js/frontend/lkn-fix-token-script.js
@@ -1,29 +1,71 @@
 (function ($) {
     $(window).on('load', () => {
+        // Suporta rest_url (padrão) e root (legado), com fallback para wpApiSettings
+        const restRoot = (typeof lknCieloRestSettings !== 'undefined' && (lknCieloRestSettings.rest_url || lknCieloRestSettings.root))
+            ? (lknCieloRestSettings.rest_url || lknCieloRestSettings.root)
+            : (typeof wpApiSettings !== 'undefined' && wpApiSettings.root ? wpApiSettings.root : null);
+
+        const nonce = (typeof lknCieloRestSettings !== 'undefined' && lknCieloRestSettings.nonce)
+            ? lknCieloRestSettings.nonce
+            : (typeof wpApiSettings !== 'undefined' && wpApiSettings.nonce ? wpApiSettings.nonce : '');
+
+        // Margem de segurança: renova um pouco antes do vencimento para evitar 401
+        // durante a autenticação 3DS.
+        const RENEW_MARGIN_SECONDS = 30;
+        // Intervalo para tentar novamente quando a renovação falhar.
+        const RETRY_DELAY_MS = 30000;
+
         const lknWcGatewayCieloRenewToken = () => {
             const expiresInput = document.querySelector('#expires_in');
             const tokenInput = document.querySelector('.bpmpi_accesstoken');
-            if (expiresInput && tokenInput) {
-                let expiresInSeconds = parseInt(expiresInput.value);
-                setTimeout(() => {
-                    $.ajax({
-                        url: lknCieloRestSettings.root + 'lknWCGatewayCielo/getAcessToken',
-                        contentType: 'application/json',
-                        method: 'GET',
-                        headers: {
-                            'X-WP-Nonce': lknCieloRestSettings.nonce
-                        },
-                        success: function(response) {
+
+            if (!restRoot) {
+                console.warn('lknCieloRestSettings.rest_url not available, skipping access token renewal');
+                return;
+            }
+
+            if (!expiresInput || !tokenInput) {
+                // Campos ainda não renderizados (checkout por blocos / ajax) — tenta de novo em breve.
+                setTimeout(lknWcGatewayCieloRenewToken, RETRY_DELAY_MS);
+                return;
+            }
+
+            let expiresInSeconds = parseInt(expiresInput.value, 10);
+
+            // Sem valor válido, assume renovação em 60s como fallback.
+            if (!expiresInSeconds || expiresInSeconds <= 0) {
+                expiresInSeconds = 60;
+            }
+
+            // Renova antes do vencimento para nunca entregar token expirado ao MPI.
+            const renewDelayMs = Math.max(0, (expiresInSeconds - RENEW_MARGIN_SECONDS)) * 1000;
+
+            setTimeout(() => {
+                $.ajax({
+                    url: restRoot + 'lknWCGatewayCielo/getAcessToken',
+                    contentType: 'application/json',
+                    method: 'GET',
+                    headers: {
+                        'X-WP-Nonce': nonce
+                    },
+                    success: function (response) {
+                        if (response && response.access_token) {
                             expiresInput.value = response.expires_in;
                             tokenInput.value = response.access_token;
                             lknWcGatewayCieloRenewToken();
-                        },
-                        error: function(error) {
-                            console.error('Error getting access token:', error);
+                        } else {
+                            // Token não gerado (credenciais/API) — tenta de novo em breve.
+                            console.error('Access token renewal returned an empty token.');
+                            setTimeout(lknWcGatewayCieloRenewToken, RETRY_DELAY_MS);
                         }
-                    });
-                }, expiresInSeconds * 1000);
-            }
+                    },
+                    error: function (error) {
+                        console.error('Error getting access token:', error);
+                        // Não desiste: se falhar, o token pode expirar e quebrar o 3DS.
+                        setTimeout(lknWcGatewayCieloRenewToken, RETRY_DELAY_MS);
+                    }
+                });
+            }, renewDelayMs);
         };
 
         lknWcGatewayCieloRenewToken();


### PR DESCRIPTION
# Cielo Payment Gateway for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, payment, paymethod, card, credit

Testado até: 7.1

Versão estável: 1.36.3

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartão de crédito, débito, Pix e Google Pay através da Cielo diretamente na sua loja WooCommerce.

## Descrição

Integre os gateways de pagamento da Cielo à sua loja WooCommerce e habilite seus clientes a pagarem via cartão de crédito, cartão de débito, Pix e Google Pay.

A [Cielo](https://www.cielo.com.br) é uma das maiores adquirentes do Brasil, oferecendo gateway seguro e eficiente para empresas aceitarem pagamentos online. O plugin oferece suporte completo aos métodos de pagamento da Cielo com autenticação 3DS 2.2 para cartões de débito e recursos avançados de parcelamento com juros/desconto.

**Recursos principais:**

- Cartão de Crédito com parcelamento inteligente
- Cartão de Débito com autenticação 3DS 2.2
- Pagamento via Pix
- Google Pay
- Cálculos de juros/desconto nos parcelamentos
- Compatibilidade com WooCommerce Blocks (Editor de Blocos)
- Layout responsivo e moderno
- Validação de BIN automática
- Suporte a múltiplas moedas

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Cielo Payment Gateway for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Cielo Payment Gateway for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os métodos Cielo desejados.
3. Configure suas credenciais da Cielo (MerchantId, MerchantKey).
4. Configure as opções de parcelamento e juros conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Cielo.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Correção: Ajuste na geração do token de autenticação 3DS.