### PR TITLE
1.37.1 - wc_cielo_payment_gateway (Ajuste no gatway de pagamento 3DS)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "8.2"
-  DEPLOY_TAG: "1.37.0"
+  DEPLOY_TAG: "1.37.1"
 
 jobs:
   release-build:

--- a/.github/workflows/wordpressRelease.yml
+++ b/.github/workflows/wordpressRelease.yml
@@ -6,7 +6,7 @@ on:
 env:
   PLUGIN_NAME: lkn-wc-gateway-cielo
   PHP_VERSION: "8.2"
-  DEPLOY_TAG: "1.37.0"
+  DEPLOY_TAG: "1.37.1"
 
 jobs:
   deploy-to-wp:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,4 +446,4 @@ composer test:unit   # Apenas testes unitários
 
 ---
 
-*Última atualização: análise da v1.37.0 — 2026. Este documento reflete os padrões observados no código e as correções de anti-padrões identificados.*
+*Última atualização: análise da v1.37.1 — 2026. Este documento reflete os padrões observados no código e as correções de anti-padrões identificados.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.37.1 - 24/08/2026
+* Correção: Ajuste no sistema 3DS no checkout por shortcode/clássico e em blocos (Gutenberg).
+* Correção: Ajuste na exibição das bandeiras dos cartões no checkout em blocos (Gutenberg).
+* Ajuste: Correções no botão de finalizar pagamento (opção padrão e centralização).
+* Ajuste: Remoção de CSS inline.
+
 # 1.37.0 - 18/08/2026
 * Ajuste: Separação do script MPI 3DS por ambiente (produção/sandbox).
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.linknacional.com.br/wordpress/woocommerce/cielo/
 Tags: pagamento, cielo, pix, woocommerce, creditcard
 Requires at least: 6.0
 Tested up to: 7.1
-Stable tag: 1.37.0
+Stable tag: 1.37.1
 Requires PHP: 8.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -116,6 +116,13 @@ CIELO API PIX, credit card, debit payment for WooCommerceCIELO API PIX, credit c
 7. Debit card front page with payment fields.
 
 == Changelog ==
+
+= 1.37.1 =
+** 24/08/2026 **
+* Fix: Adjusted the 3DS system in shortcode/classic and block (Gutenberg) checkout.
+* Fix: Adjusted card brand display in block (Gutenberg) checkout.
+* Tweak: Fixes to the finish payment button (default option and centering).
+* Tweak: Removed inline CSS.
 
 = 1.37.0 =
 ** 18/08/2026 **

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -1601,20 +1601,9 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
 
                         throw new Exception(esc_attr($message));
                     }
-                    if (empty($xid) && $this->get_option('allow_card_ineligible', 'no') == 'no') {
-                        $message = __('Invalid Cielo 3DS 2.2 authentication.', 'lkn-wc-gateway-cielo');
-
-                        // Salvar metadados da transação com dados customizados para erro de autenticação 3DS
-                        $customErrorResponse = LknWcCieloHelper::createCustomErrorResponse(
-                            401,
-                            'BP900',
-                            'Operation failure'
-                        );
-                        LknWcCieloHelper::saveTransactionMetadata($order, $customErrorResponse, $cardNum, $cardExpShort, $cardName, $installments, $amount, $currency, $provider, $merchantId, $merchantSecret, $merchantOrderId, $order_id, $capture, null, $cardType, 'lkn_dc_cvc', $this, $xid, $cavv, $eci, $version, $refId);
-                        $order->save();
-
-                        throw new Exception(esc_attr($message));
-                    }
+                    // No 3DS 2.2 o XID não é retornado (campo legado do 3DS 1.0).
+                    // A autenticação é válida quando CAVV e ECI estão presentes.
+                    // Exigir XID aqui fazia TODA autenticação 2.2 ser recusada.
 
                     $args['headers'] = array(
                         'Content-Type' => 'application/json',

--- a/includes/LknWCGatewayCieloDebit.php
+++ b/includes/LknWCGatewayCieloDebit.php
@@ -593,6 +593,23 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
     {
         try {
             $env = $this->get_option('env');
+
+            // Reutiliza um access token 3DS ainda válido da sessão. Gera um novo
+            // apenas quando não existe ou está expirado. Isso evita chamar
+            // /v2/auth/token/ a cada re-render do checkout (updated_checkout), o
+            // que causava rate-limit / troca de ReferenceId e resultava em 401
+            // intermitente no /v2/3ds/init.
+            $sessionKey = 'lkn_cielo_3ds_access_token_' . $env;
+            if (WC()->session) {
+                $cached = WC()->session->get($sessionKey, null);
+                if (is_array($cached) && ! empty($cached['access_token']) && ! empty($cached['expires_at']) && $cached['expires_at'] > time()) {
+                    return array(
+                        'access_token' => $cached['access_token'],
+                        'expires_in' => max(1, (int) ($cached['expires_at'] - time())),
+                    );
+                }
+            }
+
             $clientId = $this->get_option('client_id');
             $clientSecret = $this->get_option('client_secret');
             $url = ('sandbox' === $env) ? 'https://mpisandbox.braspag.com.br/v2/auth/token/' : 'https://mpi.braspag.com.br/v2/auth/token/';
@@ -630,9 +647,20 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
             $responseDecoded = json_decode($response['body']);
 
             if (isset($responseDecoded->access_token)) {
+                $expiresIn = isset($responseDecoded->expires_in) ? (int) $responseDecoded->expires_in : 1200;
+                // Margem de segurança de 60s para não usar token prestes a expirar.
+                $expiresIn = max(1, $expiresIn - 60);
+
+                if (WC()->session) {
+                    WC()->session->set($sessionKey, array(
+                        'access_token' => $responseDecoded->access_token,
+                        'expires_at'   => time() + $expiresIn,
+                    ));
+                }
+
                 return array(
                     'access_token' => $responseDecoded->access_token,
-                    'expires_in' => $responseDecoded->expires_in,
+                    'expires_in' => $expiresIn,
                 );
             }
         } catch (Exception $e) {
@@ -663,9 +691,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
             $product = $cart_item['data'];
             $total += $product->get_price() * $cart_item['quantity'];
         }
-        return number_format($total, 2, '', '');
-
-        return 0;
+        // Valor em centavos sem zero à esquerda (ex.: R$ 0,10 -> "10").
+        return (string) (int) round($total * 100);
     }
 
     /**
@@ -915,8 +942,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
         }
         $activeInstallment = $this->get_option('installment_payment');
         $total_cart = number_format($this->get_subtotal_plus_shipping(), 2, '.', '');
-        // Para 3DS 2.2, o valor deve estar em centavos (sem vírgula decimal)
-        $total_cart_3ds = number_format($this->get_subtotal_plus_shipping(), 2, '', '');
+        // Para 3DS 2.2, o valor deve estar em centavos, sem zero à esquerda.
+        $total_cart_3ds = (string) (int) round($this->get_subtotal_plus_shipping() * 100);
         $fees_total = number_format($this->get_fees_total(), 2, '.', '');
         $taxes_total = number_format($this->get_taxes_total(), 2, '.', '');
         $discounts_total = number_format($this->get_discounts_total(), 2, '.', '');
@@ -925,6 +952,22 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
             : array('access_token' => '', 'expires_in' => 0);
         $url = get_page_link();
         $nonce = wp_create_nonce('nonce_lkn_cielo_debit');
+
+        // Order number do 3DS precisa ser ESTÁVEL entre o /v2/3ds/init e o
+        // /v2/3ds/enroll. Antes era gerado com uniqid() direto no template, o que
+        // mudava a cada re-render (updated_checkout) e fazia o enroll falhar com
+        // 400 "Invalid enrollment request" por não bater com o token do init.
+        $order_number_3ds = '';
+        if (WC()->session) {
+            $order_number_3ds = (string) WC()->session->get('lkn_cielo_3ds_order_number', '');
+        }
+        if ('' === $order_number_3ds) {
+            $order_number_3ds = uniqid();
+            if (WC()->session) {
+                WC()->session->set('lkn_cielo_3ds_order_number', $order_number_3ds);
+            }
+        }
+
         $placeholder = $this->get_option('placeholder', 'no');
         $placeholderEnabled = false;
         $noLoginCheckout = isset($_GET['pay_for_order']) ? sanitize_text_field(wp_unslash($_GET['pay_for_order'])) : 'false';
@@ -975,8 +1018,8 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
                 $order_id = wc_get_order_id_by_order_key($key);
                 $order = wc_get_order($order_id);
                 $total_cart = number_format($order->get_total(), 2, '.', '');
-                // Para 3DS 2.2, o valor deve estar em centavos (sem vírgula decimal)
-                $total_cart_3ds = number_format($order->get_total(), 2, '', '');
+                // Para 3DS 2.2, o valor deve estar em centavos, sem zero à esquerda.
+                $total_cart_3ds = (string) (int) round($order->get_total() * 100);
             }
         }
 
@@ -1051,6 +1094,7 @@ final class LknWCGatewayCieloDebit extends WC_Payment_Gateway
         $discounts_total = $discounts_total;
         $total_cart = $total_cart;
         $total_cart_3ds = $total_cart_3ds;
+        $order_number_3ds = $order_number_3ds;
         $installments = $installments;
         $nonce = $nonce;
         $url = $url;

--- a/includes/templates/lkn-cielo-debit-payment-fields-default-layout.php
+++ b/includes/templates/lkn-cielo-debit-payment-fields-default-layout.php
@@ -105,7 +105,7 @@ if (! defined('ABSPATH')) {
         size="50"
         name="lkn_order_number"
         class="bpmpi_ordernumber"
-        value="<?php echo esc_attr(uniqid()); ?>" />
+        value="<?php echo esc_attr(isset($order_number_3ds) && '' !== $order_number_3ds ? $order_number_3ds : uniqid()); ?>" />
     <input
         type="hidden"
         name="lkn_currency"
@@ -253,7 +253,7 @@ if (! defined('ABSPATH')) {
         id="lkn_bpmpi_useraccount_guest"
         name="lkn_card_useraccount_guest"
         class="bpmpi_useraccount_guest"
-        value="<?php echo esc_attr($user_guest); ?>" />
+        value="<?php echo ($user_guest ? 'true' : 'false'); ?>" />
     <input
         type="hidden"
         id="lkn_bpmpi_useraccount_authenticationmethod"

--- a/includes/templates/lkn-cielo-debit-payment-fields-modern-layout.php
+++ b/includes/templates/lkn-cielo-debit-payment-fields-modern-layout.php
@@ -130,7 +130,7 @@ if (!defined('ABSPATH')) {
         <input type="hidden" name="lkn_auth_suppresschallenge" class="bpmpi_auth_suppresschallenge" value="false" />
         <input type="hidden" name="lkn_access_token" class="bpmpi_accesstoken" value="<?php echo esc_attr($access_token['access_token']); ?>" />
         <input type="hidden" name="lkn_expires_in" id="expires_in" value="<?php echo esc_attr($access_token['expires_in']); ?>" />
-        <input type="hidden" size="50" name="lkn_order_number" class="bpmpi_ordernumber" value="<?php echo esc_attr(uniqid()); ?>" />
+        <input type="hidden" size="50" name="lkn_order_number" class="bpmpi_ordernumber" value="<?php echo esc_attr(isset($order_number_3ds) && '' !== $order_number_3ds ? $order_number_3ds : uniqid()); ?>" />
         <input type="hidden" name="lkn_currency" class="bpmpi_currency" value="BRL" />
         <input type="hidden" size="50" id="lkn_cielo_3ds_value" name="lkn_amount" class="bpmpi_totalamount" value="<?php echo esc_attr($total_cart_3ds); ?>" />
         <input type="hidden" size="2" name="lkn_installments" class="bpmpi_installments" value="1" />
@@ -154,7 +154,7 @@ if (!defined('ABSPATH')) {
         <input type="hidden" size="8" id="lkn_bpmpi_billto_zipcode" name="lkn_card_billto_zipcode" class="bpmpi_billto_zipcode" value="<?php echo esc_attr($billing_postcode); ?>" />
         <input type="hidden" size="2" id="lkn_bpmpi_billto_country" name="lkn_card_billto_country" class="bpmpi_billto_country" value="<?php echo esc_attr($billing_country); ?>" />
         <input type="hidden" id="lkn_bpmpi_shipto_sameasbillto" name="lkn_card_shipto_sameasbillto" class="bpmpi_shipto_sameasbillto" value="true" />
-        <input type="hidden" id="lkn_bpmpi_useraccount_guest" name="lkn_card_useraccount_guest" class="bpmpi_useraccount_guest" value="<?php echo esc_attr($user_guest); ?>" />
+        <input type="hidden" id="lkn_bpmpi_useraccount_guest" name="lkn_card_useraccount_guest" class="bpmpi_useraccount_guest" value="<?php echo ($user_guest ? 'true' : 'false'); ?>" />
         <input type="hidden" id="lkn_bpmpi_useraccount_authenticationmethod" name="lkn_card_useraccount_authenticationmethod" class="bpmpi_useraccount_authenticationmethod" value="<?php echo esc_attr($authentication_method); ?>" />
         <input type="hidden" size="45" id="lkn_bpmpi_device_ipaddress" name="lkn_card_device_ipaddress" class="bpmpi_device_ipaddress" value="<?php echo esc_attr($client_ip); ?>" />
         <input type="hidden" size="7" id="lkn_bpmpi_device_channel" name="lkn_card_device_channel" class="bpmpi_device_channel" value="Browser" />

--- a/lkn-wc-gateway-cielo-file.php
+++ b/lkn-wc-gateway-cielo-file.php
@@ -17,7 +17,7 @@ require_once __DIR__ . '/vendor/autoload.php';
  * Rename this for your plugin and update it as you release new versions.
  */
 if (! defined('LKN_WC_CIELO_VERSION')) {
-    define('LKN_WC_CIELO_VERSION', '1.37.0');
+    define('LKN_WC_CIELO_VERSION', '1.37.1');
 }
 
 if (! defined('LKN_WC_CIELO_FILE')) {

--- a/lkn-wc-gateway-cielo.php
+++ b/lkn-wc-gateway-cielo.php
@@ -16,7 +16,7 @@
  * Plugin Name:       CIELO API PIX, credit card, debit payment for WooCommerce
  * Plugin URI:        https://www.linknacional.com.br/wordpress/woocommerce/cielo/
  * Description:       Adds the Cielo API 3.0 Payments gateway to your WooCommerce website.
- * Version:           1.37.0
+ * Version:           1.37.1
  * Requires PHP:      8.2
  * Requires at least: 6.0
  * Author:            Link Nacional

--- a/resources/css/frontend/lkn-dc-style.css
+++ b/resources/css/frontend/lkn-dc-style.css
@@ -36,6 +36,9 @@
 }
 
 .lkn-debit-submit-section {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     text-align: center;
     margin-bottom: 16px;
 }

--- a/resources/js/debitCard/lkn-dc-script-prd.js
+++ b/resources/js/debitCard/lkn-dc-script-prd.js
@@ -1,6 +1,26 @@
 /* eslint-disable no-undef */
 // Implements script internationalization
 
+// O bundle do bloco (lknCieloDebitCompiled.js) NÃO esconde o botão nativo
+// "Place order" do WooCommerce blocks. Esse botão envia o checkout direto,
+// sem executar o 3DS (ECI/CAVV/XID vazios). Interceptamos o clique REAL do
+// usuário nesse botão e executamos o fluxo 3DS antes de deixar o envio seguir.
+document.addEventListener('click', function (e) {
+  var native = e.target && e.target.closest && e.target.closest('.wc-block-components-checkout-place-order-button')
+  if (!native) {
+    return
+  }
+
+  // Cliques sintéticos (disparados pelo próprio fluxo 3DS via dispatchEvent)
+  // têm isTrusted === false e devem passar direto. Só interceptamos o clique
+  // real do usuário no botão nativo.
+  if (e.isTrusted === true && typeof lknDCProccessButton === 'function') {
+    e.preventDefault()
+    e.stopPropagation()
+    lknDCProccessButton()
+  }
+}, true)
+
 function bpmpi_config () {
   return {
     onReady: function () {
@@ -158,13 +178,29 @@ function setIfExists (id, value) {
 // Função para processar cartão de débito (com 3DS)
 function lknProcessDebitCard () {
   try {
-    var cardNumber = document.getElementById('lkn_dcno').value.replace(/\D/g, '')
+    var dcNoEl = document.getElementById('lkn_dcno')
+    var cardNumber = dcNoEl ? dcNoEl.value.replace(/\D/g, '') : ''
 
-    // Se não há campo de cartão visível, não precisa de 3DS — submete direto
-    if (!document.getElementById('lkn_dcno') || !cardNumber || !document.getElementById('lkn_dcno').offsetParent) {
+    // No fluxo de blocos (Gutenberg) esta função só é executada depois que o
+    // React valida os campos do cartão. Removida a checagem de offsetParent /
+    // visibilidade, que fazia o pedido ser enviado sem 3DS (ECI/CAVV/XID
+    // vazios) e resultava em "Autenticação Cielo 3DS 2.2 inválida".
+    if (!dcNoEl || !cardNumber) {
       var btn = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
       if (btn) btn.click()
       return;
+    }
+
+    // Garante que o tipo enviado ao 3DS (bpmpi_paymentmethod) corresponda ao
+    // tipo de cartão selecionado. O bundle compilado fixa o valor em "Debit".
+    var cardTypeSelect = document.getElementById('lkn_cc_type') ||
+      document.querySelector('.lkn-credit-debit-card-type-select select') ||
+      document.querySelector('.lkn-select-type select')
+    var paymentMethodEl = document.querySelector('.bpmpi_paymentmethod')
+    var cardType = (cardTypeSelect && cardTypeSelect.value) ||
+      (paymentMethodEl && paymentMethodEl.value) || 'Debit'
+    if (paymentMethodEl) {
+      paymentMethodEl.value = cardType
     }
 
     var cardHolder = document.getElementById('lkn_dc_cardholder_name')

--- a/resources/js/debitCard/lkn-dc-script-sdb.js
+++ b/resources/js/debitCard/lkn-dc-script-sdb.js
@@ -2,6 +2,26 @@
 /* eslint-disable no-undef */
 // Implements script internationalization
 
+// O bundle do bloco (lknCieloDebitCompiled.js) NÃO esconde o botão nativo
+// "Place order" do WooCommerce blocks. Esse botão envia o checkout direto,
+// sem executar o 3DS (ECI/CAVV/XID vazios). Interceptamos o clique REAL do
+// usuário nesse botão e executamos o fluxo 3DS antes de deixar o envio seguir.
+document.addEventListener('click', function (e) {
+  var native = e.target && e.target.closest && e.target.closest('.wc-block-components-checkout-place-order-button')
+  if (!native) {
+    return
+  }
+
+  // Cliques sintéticos (disparados pelo próprio fluxo 3DS via dispatchEvent)
+  // têm isTrusted === false e devem passar direto. Só interceptamos o clique
+  // real do usuário no botão nativo.
+  if (e.isTrusted === true && typeof lknDCProccessButton === 'function') {
+    e.preventDefault()
+    e.stopPropagation()
+    lknDCProccessButton()
+  }
+}, true)
+
 function bpmpi_config () {
   return {
     onReady: function () {
@@ -158,13 +178,29 @@ function setIfExists (id, value) {
 // Função para processar cartão de débito (com 3DS)
 function lknProcessDebitCard () {
   try {
-    var cardNumber = document.getElementById('lkn_dcno').value.replace(/\D/g, '')
+    var dcNoEl = document.getElementById('lkn_dcno')
+    var cardNumber = dcNoEl ? dcNoEl.value.replace(/\D/g, '') : ''
 
-    // Se não há campo de cartão visível, não precisa de 3DS — submete direto
-    if (!document.getElementById('lkn_dcno') || !cardNumber || !document.getElementById('lkn_dcno').offsetParent) {
+    // No fluxo de blocos (Gutenberg) esta função só é executada depois que o
+    // React valida os campos do cartão. Removida a checagem de offsetParent /
+    // visibilidade, que fazia o pedido ser enviado sem 3DS (ECI/CAVV/XID
+    // vazios) e resultava em "Autenticação Cielo 3DS 2.2 inválida".
+    if (!dcNoEl || !cardNumber) {
       var btn = document.querySelectorAll('.wc-block-components-checkout-place-order-button')[0]
       if (btn) btn.click()
       return;
+    }
+
+    // Garante que o tipo enviado ao 3DS (bpmpi_paymentmethod) corresponda ao
+    // tipo de cartão selecionado. O bundle compilado fixa o valor em "Debit".
+    var cardTypeSelect = document.getElementById('lkn_cc_type') ||
+      document.querySelector('.lkn-credit-debit-card-type-select select') ||
+      document.querySelector('.lkn-select-type select')
+    var paymentMethodEl = document.querySelector('.bpmpi_paymentmethod')
+    var cardType = (cardTypeSelect && cardTypeSelect.value) ||
+      (paymentMethodEl && paymentMethodEl.value) || 'Debit'
+    if (paymentMethodEl) {
+      paymentMethodEl.value = cardType
     }
 
     var cardHolder = document.getElementById('lkn_dc_cardholder_name')

--- a/resources/js/frontend/lkn-dc-script-prd.js
+++ b/resources/js/frontend/lkn-dc-script-prd.js
@@ -7,11 +7,14 @@ let lkn3DSCompleted = false;
 
 // Provider detectado via BIN — usado para pular MPI se bandeira não tem 3DS
 let lknDetectedCardProvider = '';
+// Tipo do cartão detectado via BIN: 'Debit' | 'Credit' (vazio = indeterminado)
+let lknDetectedCardType = '';
 
 // Função para resetar o status 3DS
 function resetLkn3DSStatus() {
   lkn3DSCompleted = false;
   lknDetectedCardProvider = '';
+  lknDetectedCardType = '';
   
   // Reconfigurar o botão para tipo button (caso tenha sido alterado)
   const btnSubmit = document.getElementById('place_order');
@@ -129,6 +132,13 @@ function setupErrorDetection() {
             // Guardar provider detectado para pré-filtro 3DS
             if (response.brand) {
               lknDetectedCardProvider = response.brand.charAt(0).toUpperCase() + response.brand.slice(1);
+            }
+
+            // Guardar o tipo real do cartão (Debit/Credit) para o paymentmethod do 3DS
+            if (response.cardType === 'Debito') {
+              lknDetectedCardType = 'Debit'
+            } else if (response.cardType === 'Credito') {
+              lknDetectedCardType = 'Credit'
             }
 
             const options = document.querySelectorAll('#lkn_cc_type option')
@@ -406,31 +416,10 @@ function lknDCProccessButton () {
       javaEnabledEl.value = (typeof navigator.javaEnabled === 'function' && navigator.javaEnabled()) ? 'true' : 'false'
     }
 
-    // Preencher campos billto com fallback DOM: billing → shipping → custom
-    // Phone com 3 camadas: billing-phone → shipping-phone → custom-phone
-    function getDomValueWithFallback(ids) {
-      for (var i = 0; i < ids.length; i++) {
-        var el = document.getElementById(ids[i])
-        if (el && el.value && el.value.trim() !== '') {
-          return el.value.trim()
-        }
-      }
-      return ''
-    }
-    function setIfExists(id, value) {
-      var el = document.getElementById(id)
-      if (el) el.value = value
-    }
-    setIfExists('lkn_bpmpi_billto_phonenumber', getDomValueWithFallback(['billing-phone', 'shipping-phone', 'custom-phone']))
-    setIfExists('lkn_bpmpi_billto_street1', getDomValueWithFallback(['billing-address_1', 'shipping-address_1']))
-    setIfExists('lkn_bpmpi_billto_street2', getDomValueWithFallback(['billing-address_2', 'shipping-address_2']))
-    setIfExists('lkn_bpmpi_billto_city', getDomValueWithFallback(['billing-city', 'shipping-city']))
-    setIfExists('lkn_bpmpi_billto_state', getDomValueWithFallback(['billing-state', 'shipping-state']))
-    setIfExists('lkn_bpmpi_billto_zipcode', getDomValueWithFallback(['billing-postcode', 'shipping-postcode']))
-    setIfExists('lkn_bpmpi_billto_country', getDomValueWithFallback(['billing-country', 'shipping-country']))
-    setIfExists('lkn_bpmpi_billto_email', getDomValueWithFallback(['billing-email', 'shipping-email']))
-    setIfExists('lkn_bpmpi_billto_contactname', getDomValueWithFallback(['billing-first_name']))
-    // Se o email do DOM não foi encontrado, manter o valor já existente no campo hidden
+    // Não preencher billing via DOM (fallback JS). Os campos bpmpi_billto_*
+    // permanecem como o template PHP renderizou: preenchidos a partir do
+    // user_meta para usuário logado com perfil completo; vazios para convidado.
+    // Comportamento idêntico ao fluxo Gutenberg.
 
     // Pré-filtro por BIN: pular MPI se bandeira não suporta 3DS
     var supported3DSBrands = ['Visa', 'Mastercard', 'Elo', 'Amex', 'American Express'];
@@ -450,6 +439,28 @@ function lknDCProccessButton () {
         btnSkip.click();
       }
       return;
+    }
+
+    // O gateway aceita crédito E débito. O bpmpi_paymentmethod deve refletir o
+    // tipo REAL da operação: usa o tipo detectado via BIN quando a API
+    // consegue distinguir (Debito/Credito); caso contrário (cartão "Multiplo"),
+    // respeita o que o cliente selecionou no select lkn_cc_type.
+    var cardTypeSelect = document.getElementById('lkn_cc_type')
+    var paymentMethodEl = document.querySelector('.bpmpi_paymentmethod')
+    var cardType = (lknDetectedCardType === 'Credit' || lknDetectedCardType === 'Debit')
+      ? lknDetectedCardType
+      : ((cardTypeSelect && cardTypeSelect.value) || (paymentMethodEl && paymentMethodEl.value) || 'Credit')
+    if (paymentMethodEl) {
+      paymentMethodEl.value = cardType
+    }
+
+    // Reaplica o orderNumber congelado no load, garantindo que o enroll use o
+    // MESMO valor que o /v2/3ds/init usou (evita 400 por divergência).
+    if (window.__lknOrderNumber3ds) {
+      const orderNumberEl = document.querySelector('.bpmpi_ordernumber')
+      if (orderNumberEl) {
+        orderNumberEl.value = window.__lknOrderNumber3ds
+      }
     }
 
     bpmpi_authenticate()
@@ -480,14 +491,70 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function lknWcGatewayCieloLoadScript () {
     const scriptUrlBpmpi = lknDCDirScript3DSCieloShortCode.url
-    const existingScriptBpmpi = document.querySelector(`script[src="${scriptUrlBpmpi}"]`)
 
-    if (!existingScriptBpmpi) {
-      const scriptBpmpi = document.createElement('script')
-      scriptBpmpi.src = scriptUrlBpmpi
-      scriptBpmpi.async = true
-      document.body.appendChild(scriptBpmpi)
+    if (window.__lknBpmpiLoadStarted) {
+      return
     }
+    window.__lknBpmpiLoadStarted = true
+
+    // Congela o orderNumber que o /v2/3ds/init vai usar. O campo pode ser
+    // re-renderizado pelo updated_checkout (cache de página), fazendo o enroll
+    // enviar um orderNumber diferente do init e resultando em 400.
+    const orderNumberEl = document.querySelector('.bpmpi_ordernumber')
+    if (orderNumberEl && orderNumberEl.value) {
+      window.__lknOrderNumber3ds = orderNumberEl.value
+    }
+
+    const appendBpmpi = function () {
+      if (!document.querySelector(`script[src="${scriptUrlBpmpi}"]`)) {
+        const scriptBpmpi = document.createElement('script')
+        scriptBpmpi.src = scriptUrlBpmpi
+        scriptBpmpi.async = true
+        document.body.appendChild(scriptBpmpi)
+      }
+    }
+
+    // O access token embutido no HTML pode estar expirado (cache de página),
+    // o que faz o /v2/3ds/init devolver 401. Busca um token fresco via REST
+    // antes de carregar o BP.Mpi (igual ao fluxo Gutenberg).
+    const restRoot = (typeof lknCieloRestSettings !== 'undefined' && lknCieloRestSettings.rest_url)
+      ? lknCieloRestSettings.rest_url
+      : null
+    const nonce = (typeof lknCieloRestSettings !== 'undefined' && lknCieloRestSettings.nonce)
+      ? lknCieloRestSettings.nonce
+      : ''
+
+    if (!restRoot) {
+      appendBpmpi()
+      return
+    }
+
+    fetch(restRoot + 'lknWCGatewayCielo/getAcessToken', {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'X-WP-Nonce': nonce
+      }
+    })
+      .then(function (res) { return res.json() })
+      .then(function (data) {
+        if (data && data.access_token) {
+          const tokenEl = document.getElementsByClassName('bpmpi_accesstoken')[0]
+          if (tokenEl) {
+            tokenEl.value = data.access_token
+          }
+          if (data.expires_in) {
+            const expEl = document.getElementById('expires_in')
+            if (expEl) {
+              expEl.value = data.expires_in
+            }
+          }
+        }
+        appendBpmpi()
+      })
+      .catch(function () {
+        appendBpmpi()
+      })
   }
 })
 

--- a/resources/js/frontend/lkn-dc-script-sdb.js
+++ b/resources/js/frontend/lkn-dc-script-sdb.js
@@ -5,11 +5,14 @@ let lkn3DSCompleted = false;
 
 // Provider detectado via BIN — usado para pular MPI se bandeira não tem 3DS
 let lknDetectedCardProvider = '';
+// Tipo do cartão detectado via BIN: 'Debit' | 'Credit' (vazio = indeterminado)
+let lknDetectedCardType = '';
 
 // Função para resetar o status 3DS
 function resetLkn3DSStatus() {
   lkn3DSCompleted = false;
   lknDetectedCardProvider = '';
+  lknDetectedCardType = '';
   
   // Reconfigurar o botão para tipo button (caso tenha sido alterado)
   const btnSubmit = document.getElementById('place_order');
@@ -127,6 +130,13 @@ function setupErrorDetection() {
             // Guardar provider detectado para pré-filtro 3DS
             if (response.brand) {
               lknDetectedCardProvider = response.brand.charAt(0).toUpperCase() + response.brand.slice(1);
+            }
+
+            // Guardar o tipo real do cartão (Debit/Credit) para o paymentmethod do 3DS
+            if (response.cardType === 'Debito') {
+              lknDetectedCardType = 'Debit'
+            } else if (response.cardType === 'Credito') {
+              lknDetectedCardType = 'Credit'
             }
 
             const options = document.querySelectorAll('#lkn_cc_type option')
@@ -414,31 +424,10 @@ function lknDCProccessButton() {
       javaEnabledEl.value = (typeof navigator.javaEnabled === 'function' && navigator.javaEnabled()) ? 'true' : 'false'
     }
 
-    // Preencher campos billto com fallback DOM: billing → shipping → custom
-    // Phone com 3 camadas: billing-phone → shipping-phone → custom-phone
-    function getDomValueWithFallback(ids) {
-      for (var i = 0; i < ids.length; i++) {
-        var el = document.getElementById(ids[i])
-        if (el && el.value && el.value.trim() !== '') {
-          return el.value.trim()
-        }
-      }
-      return ''
-    }
-    function setIfExists(id, value) {
-      var el = document.getElementById(id)
-      if (el) el.value = value
-    }
-    setIfExists('lkn_bpmpi_billto_phonenumber', getDomValueWithFallback(['billing-phone', 'shipping-phone', 'custom-phone']))
-    setIfExists('lkn_bpmpi_billto_street1', getDomValueWithFallback(['billing-address_1', 'shipping-address_1']))
-    setIfExists('lkn_bpmpi_billto_street2', getDomValueWithFallback(['billing-address_2', 'shipping-address_2']))
-    setIfExists('lkn_bpmpi_billto_city', getDomValueWithFallback(['billing-city', 'shipping-city']))
-    setIfExists('lkn_bpmpi_billto_state', getDomValueWithFallback(['billing-state', 'shipping-state']))
-    setIfExists('lkn_bpmpi_billto_zipcode', getDomValueWithFallback(['billing-postcode', 'shipping-postcode']))
-    setIfExists('lkn_bpmpi_billto_country', getDomValueWithFallback(['billing-country', 'shipping-country']))
-    setIfExists('lkn_bpmpi_billto_email', getDomValueWithFallback(['billing-email', 'shipping-email']))
-    setIfExists('lkn_bpmpi_billto_contactname', getDomValueWithFallback(['billing-first_name']))
-    // Se o email do DOM não foi encontrado, manter o valor já existente no campo hidden
+    // Não preencher billing via DOM (fallback JS). Os campos bpmpi_billto_*
+    // permanecem como o template PHP renderizou: preenchidos a partir do
+    // user_meta para usuário logado com perfil completo; vazios para convidado.
+    // Comportamento idêntico ao fluxo Gutenberg.
 
     // Pré-filtro por BIN: pular MPI se bandeira não suporta 3DS
     var supported3DSBrands = ['Visa', 'Mastercard', 'Elo', 'Amex', 'American Express'];
@@ -458,6 +447,28 @@ function lknDCProccessButton() {
         btnSkip.click();
       }
       return;
+    }
+
+    // O gateway aceita crédito E débito. O bpmpi_paymentmethod deve refletir o
+    // tipo REAL da operação: usa o tipo detectado via BIN quando a API
+    // consegue distinguir (Debito/Credito); caso contrário (cartão "Multiplo"),
+    // respeita o que o cliente selecionou no select lkn_cc_type.
+    var cardTypeSelect = document.getElementById('lkn_cc_type')
+    var paymentMethodEl = document.querySelector('.bpmpi_paymentmethod')
+    var cardType = (lknDetectedCardType === 'Credit' || lknDetectedCardType === 'Debit')
+      ? lknDetectedCardType
+      : ((cardTypeSelect && cardTypeSelect.value) || (paymentMethodEl && paymentMethodEl.value) || 'Credit')
+    if (paymentMethodEl) {
+      paymentMethodEl.value = cardType
+    }
+
+    // Reaplica o orderNumber congelado no load, garantindo que o enroll use o
+    // MESMO valor que o /v2/3ds/init usou (evita 400 por divergência).
+    if (window.__lknOrderNumber3ds) {
+      const orderNumberEl = document.querySelector('.bpmpi_ordernumber')
+      if (orderNumberEl) {
+        orderNumberEl.value = window.__lknOrderNumber3ds
+      }
     }
 
     bpmpi_authenticate()
@@ -488,14 +499,70 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function lknWcGatewayCieloLoadScript() {
     const scriptUrlBpmpi = lknDCDirScript3DSCieloShortCode.url
-    const existingScriptBpmpi = document.querySelector(`script[src="${scriptUrlBpmpi}"]`)
 
-    if (!existingScriptBpmpi) {
-      const scriptBpmpi = document.createElement('script')
-      scriptBpmpi.src = scriptUrlBpmpi
-      scriptBpmpi.async = true
-      document.body.appendChild(scriptBpmpi)
+    if (window.__lknBpmpiLoadStarted) {
+      return
     }
+    window.__lknBpmpiLoadStarted = true
+
+    // Congela o orderNumber que o /v2/3ds/init vai usar. O campo pode ser
+    // re-renderizado pelo updated_checkout (cache de página), fazendo o enroll
+    // enviar um orderNumber diferente do init e resultando em 400.
+    const orderNumberEl = document.querySelector('.bpmpi_ordernumber')
+    if (orderNumberEl && orderNumberEl.value) {
+      window.__lknOrderNumber3ds = orderNumberEl.value
+    }
+
+    const appendBpmpi = function () {
+      if (!document.querySelector(`script[src="${scriptUrlBpmpi}"]`)) {
+        const scriptBpmpi = document.createElement('script')
+        scriptBpmpi.src = scriptUrlBpmpi
+        scriptBpmpi.async = true
+        document.body.appendChild(scriptBpmpi)
+      }
+    }
+
+    // O access token embutido no HTML pode estar expirado (cache de página),
+    // o que faz o /v2/3ds/init devolver 401. Busca um token fresco via REST
+    // antes de carregar o BP.Mpi (igual ao fluxo Gutenberg).
+    const restRoot = (typeof lknCieloRestSettings !== 'undefined' && lknCieloRestSettings.rest_url)
+      ? lknCieloRestSettings.rest_url
+      : null
+    const nonce = (typeof lknCieloRestSettings !== 'undefined' && lknCieloRestSettings.nonce)
+      ? lknCieloRestSettings.nonce
+      : ''
+
+    if (!restRoot) {
+      appendBpmpi()
+      return
+    }
+
+    fetch(restRoot + 'lknWCGatewayCielo/getAcessToken', {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'X-WP-Nonce': nonce
+      }
+    })
+      .then(function (res) { return res.json() })
+      .then(function (data) {
+        if (data && data.access_token) {
+          const tokenEl = document.getElementsByClassName('bpmpi_accesstoken')[0]
+          if (tokenEl) {
+            tokenEl.value = data.access_token
+          }
+          if (data.expires_in) {
+            const expEl = document.getElementById('expires_in')
+            if (expEl) {
+              expEl.value = data.expires_in
+            }
+          }
+        }
+        appendBpmpi()
+      })
+      .catch(function () {
+        appendBpmpi()
+      })
   }
 })
 


### PR DESCRIPTION
# Cielo Payment Gateway for WooCommerce

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: woocommerce, payment, paymethod, card, credit

Testado até: 7.1

Versão estável: 1.37.1

Licença: GPLv2 ou posterior

URI da Licença: https://opensource.org/licenses/MIT

Traduções: Português(Brasil) / Inglês

Receba pagamentos por meio de cartão de crédito, débito, Pix e Google Pay através da Cielo diretamente na sua loja WooCommerce.

## Descrição

Integre os gateways de pagamento da Cielo à sua loja WooCommerce e habilite seus clientes a pagarem via cartão de crédito, cartão de débito, Pix e Google Pay.

A [Cielo](https://www.cielo.com.br) é uma das maiores adquirentes do Brasil, oferecendo gateway seguro e eficiente para empresas aceitarem pagamentos online. O plugin oferece suporte completo aos métodos de pagamento da Cielo com autenticação 3DS 2.2 para cartões de débito e recursos avançados de parcelamento com juros/desconto.

**Recursos principais:**

- Cartão de Crédito com parcelamento inteligente
- Cartão de Débito com autenticação 3DS 2.2
- Pagamento via Pix
- Google Pay
- Cálculos de juros/desconto nos parcelamentos
- Compatibilidade com WooCommerce Blocks (Editor de Blocos)
- Layout responsivo e moderno
- Validação de BIN automática
- Suporte a múltiplas moedas

**Dependências**

Este plugin depende do WooCommerce. Certifique-se de que o WooCommerce está instalado e configurado antes de instalar o Cielo Payment Gateway for WooCommerce.

**Instruções de uso**

1. Procure na barra lateral do WordPress por 'Cielo Payment Gateway for WooCommerce'.
2. Nas opções do WooCommerce, acesse 'Pagamentos' e configure os métodos Cielo desejados.
3. Configure suas credenciais da Cielo (MerchantId, MerchantKey).
4. Configure as opções de parcelamento e juros conforme necessário.
5. Salve as configurações.

Pronto! Seus clientes poderão pagar via Cielo.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".
5. Certifique-se de que o plugin WooCommerce também está ativado.

## CHANGELOG:

* Correção: Ajuste no sistema 3DS no checkout por shortcode/clássico e em blocos (Gutenberg).
* Correção: Ajuste na exibição das bandeiras dos cartões no checkout em blocos (Gutenberg).
* Ajuste: Correções no botão de finalizar pagamento (opção padrão e centralização).
* Ajuste: Remoção de CSS inline.